### PR TITLE
Add BattleRoom skeleton and flow docs

### DIFF
--- a/Documents/PlayerJourney.md
+++ b/Documents/PlayerJourney.md
@@ -1,0 +1,18 @@
+# Player Journey Conceptual Flow
+
+This document outlines the step-by-step flow that a player experiences in **Soul Steel**.
+
+1. **Join the experience** – teleport to the Hub lobby.
+2. **ProfileService** loads persistent data such as currency and the player's gem inventory.
+3. The **Lobby UI** allows rolling for new Gems and displays equipped Manifestation slots. First-time players are granted a free *Starter Gem*.
+4. **Matchmaking board**
+   - Selecting **Create Room** makes a new `BattleRoom` instance and returns the room ID.
+   - Friends may **Join** using that ID to enter the same room.
+5. A **countdown** (default 30 s) starts once the first player joins.
+   - During the countdown each participant can swap their active Manifestation Gem.
+   - Chosen gem data replicates read-only to all clients for preview.
+6. When the countdown ends a dedicated **Battle Place** is reserved via `TeleportService` with the participant list and their gem IDs.
+7. In the **Battle Place** each server creates a `TeamSpawner` for every player which spawns the NPC squad defined by their gem.
+   Combat runs until the wave scheduler or free‑for‑all rules determine victory.
+8. **Results** (win, participation rewards, new currency) are saved back with `ProfileService` and players return to the Lobby.
+

--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -16,6 +16,7 @@ The table below lists core modules grouped by network layer and their current st
 |Server|`server/main.server.ts`|Under Construction|Joins players and loads profiles|
 |Server|`server/network/network.server.ts`|Usable|Server network handlers|
 |Server|`server/services/ProfileService.ts`|Under Construction|Loads player profiles|
+|Server|`server/services/BattleRoomService.ts`|Stub|Matchmaking and teleport skeleton|
 |Server|`server/entity/Manifestation.ts`|Stub|Placeholder creation logic|
 
 Keep this summary updated whenever modules are added or changed.

--- a/src/server/main.server.ts
+++ b/src/server/main.server.ts
@@ -9,11 +9,12 @@
 
 /* =============================================== Imports =============================================== */
 import { Players } from "@rbxts/services";
-import { ManifestationForgeService, DataProfileController } from "./services";
+import { ManifestationForgeService, DataProfileController, BattleRoomService } from "./services";
 
 /* =============================================== Initialization ========================================= */
 DataProfileController.Start();
 ManifestationForgeService.Start();
+BattleRoomService.Start();
 
 /* ================== Player Joined Event ================== */
 Players.PlayerAdded.Connect((player) => {

--- a/src/server/network/network.server.ts
+++ b/src/server/network/network.server.ts
@@ -25,7 +25,7 @@ import { HttpService } from "@rbxts/services";
 import { Network } from "shared/network";
 
 /* Custom Services */
-import { DataProfileController } from "server/services";
+import { DataProfileController, BattleRoomService } from "server/services";
 
 /* Factories and Types */
 import { AttributeKey } from "shared/data";
@@ -69,6 +69,19 @@ Network.Server.OnEvent("AddGem", (player, gemid: string) => {
 	}
 
 	print(`Added gem to player ${player.Name}'s profile:`, profile.Data);
+});
+
+// MATCHMAKING -----------------------------------------------------
+Network.Server.Get("CreateRoom").SetCallback((player) => {
+	return BattleRoomService.CreateRoom(player);
+});
+
+Network.Server.OnEvent("JoinRoom", (player, roomId: string) => {
+	BattleRoomService.JoinRoom(player, roomId);
+});
+
+Network.Server.OnEvent("SetActiveGem", (player, roomId: string, gemId: string) => {
+	BattleRoomService.SetActiveGem(player, roomId, gemId);
 });
 
 print("Network server initialized and listening for events.");

--- a/src/server/services/BattleRoomService.ts
+++ b/src/server/services/BattleRoomService.ts
@@ -1,0 +1,103 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        BattleRoomService.ts
+ * @module      BattleRoomService
+ * @layer       Server/Services
+ * @classType   Singleton
+ * @description Handles creation of battle rooms and teleports players to the battle place.
+ */
+
+/* =============================================== Imports ================================== */
+import { HttpService, TeleportService } from "@rbxts/services";
+import { Network } from "shared/network";
+
+/* =============================================== Constants ================================= */
+const COUNTDOWN_TIME = 30; // seconds
+const BATTLE_PLACE_ID = 0; // TODO: replace with actual place ID
+
+/* =============================================== Types ===================================== */
+interface BattleRoom {
+	id: string;
+	players: Map<Player, string>; // Player → active gemId
+	countdownTask?: thread;
+}
+
+/* =============================================== Service =================================== */
+export class BattleRoomService {
+	private static _instance: BattleRoomService | undefined;
+	private static _rooms = new Map<string, BattleRoom>();
+
+	private constructor() {
+		print("BattleRoomService initialized.");
+	}
+
+	public static Start(): BattleRoomService {
+		if (this._instance === undefined) {
+			this._instance = new BattleRoomService();
+		}
+		return this._instance;
+	}
+
+	/* ------------------------------- Public API ------------------------------- */
+
+	public static CreateRoom(owner: Player): string {
+		this.Start();
+		const id = HttpService.GenerateGUID(false);
+		const room: BattleRoom = {
+			id,
+			players: new Map<Player, string>(),
+		};
+		this._rooms.set(id, room);
+		this.JoinRoom(owner, id);
+		return id;
+	}
+
+	public static JoinRoom(player: Player, roomId: string) {
+		const room = this._rooms.get(roomId);
+		if (!room) {
+			warn(`BattleRoom ${roomId} not found`);
+			return;
+		}
+		if (!room.players.has(player)) {
+			room.players.set(player, "");
+		}
+		if (!room.countdownTask) {
+			this._startCountdown(room);
+		}
+	}
+
+	public static SetActiveGem(player: Player, roomId: string, gemId: string) {
+		const room = this._rooms.get(roomId);
+		if (!room) return;
+		if (room.players.has(player)) {
+			room.players.set(player, gemId);
+		}
+	}
+
+	/* ------------------------------- Internal ------------------------------- */
+
+	private static _startCountdown(room: BattleRoom) {
+		room.countdownTask = task.spawn(() => {
+			for (let remaining = COUNTDOWN_TIME; remaining > 0; remaining--) {
+				const players = this._collectPlayers(room);
+				Network.Server.Get("RoomCountdown").SendToPlayers(players, room.id, remaining);
+				task.wait(1);
+			}
+			this._launchRoom(room);
+		});
+	}
+
+	private static _collectPlayers(room: BattleRoom): Player[] {
+		const result = new Array<Player>();
+		room.players.forEach((_, p) => result.push(p));
+		return result;
+	}
+
+	private static _launchRoom(room: BattleRoom) {
+		const players = this._collectPlayers(room);
+		const [code] = TeleportService.ReserveServer(BATTLE_PLACE_ID);
+		TeleportService.TeleportToPrivateServer(BATTLE_PLACE_ID, code, players);
+		this._rooms.delete(room.id);
+	}
+}

--- a/src/server/services/index.ts
+++ b/src/server/services/index.ts
@@ -22,3 +22,4 @@
 
 export * from "./ProfileService";
 export * from "./ManifestationForgeService";
+export * from "./BattleRoomService";

--- a/src/shared/network/Definitions.ts
+++ b/src/shared/network/Definitions.ts
@@ -17,7 +17,13 @@ export const Network = Net.Definitions.Create({
 	SpawnManifestation: Net.Definitions.ClientToServerEvent<[formId: string, abilityId: string, bonusId: string]>(),
 	IncreaseAttribute: Net.Definitions.ClientToServerEvent<[attributeKey: AttributeKey, amount: number]>(),
 	AddGem: Net.Definitions.ClientToServerEvent<[gemid: string]>(),
+	JoinRoom: Net.Definitions.ClientToServerEvent<[roomId: string]>(),
+	SetActiveGem: Net.Definitions.ClientToServerEvent<[roomId: string, gemId: string]>(),
+
+	// client → server function
+	CreateRoom: Net.Definitions.ServerFunction<() => string>(),
 
 	// server → client
 	ProfileChanged: Net.Definitions.ServerToClientEvent<[data: unknown]>(),
+	RoomCountdown: Net.Definitions.ServerToClientEvent<[roomId: string, remaining: number]>(),
 });


### PR DESCRIPTION
## Summary
- document the player journey flow
- implement `BattleRoomService` for room creation and countdown
- extend network definitions and handlers for room actions
- start BattleRoomService on the server
- update development summary

## Testing
- `npm run lint`
- `npm run lint:fix`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685af5be1198832782762619d200920b