### PR TITLE
Implement Gem Forge screen UI

### DIFF
--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -14,7 +14,7 @@ The table below lists core modules grouped by network layer and their current st
 |Client|`client/stylesheet.client.ts`|Under Construction|StyleSheet prototype|
 |Client|`client/ui/atoms`|Usable|Core UI atoms (buttons, panels)|
 |Client|`client/ui/style`|Rock Solid|Tokenized layout and colors|
-|Client|`client/ui/screens`|Stub|Gem forge placeholder screen|
+|Client|`client/ui/screens`|Under Construction|Gem forge screen basic layout|
 |Server|`server/main.server.ts`|Under Construction|Joins players and loads profiles|
 |Server|`server/network/network.server.ts`|Usable|Server network handlers|
 |Server|`server/services/ProfileService.ts`|Under Construction|Loads player profiles|

--- a/src/client/ui/atoms/Gem/GemSlot.ts
+++ b/src/client/ui/atoms/Gem/GemSlot.ts
@@ -1,0 +1,64 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        GemSlot.ts
+ * @module      GemSlot
+ * @layer       Client/UI/Atoms
+ * @description Clickable inventory gem slot with rarity border and icon.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Codex
+ * @license      MIT
+ * @since        0.2.1
+ * @lastUpdated  2025-07-01 by Codex – Initial creation
+ *
+ * @dependencies
+ *   @rbxts/fusion ^0.4.0
+ */
+// #AGENT_ATOM
+import Fusion, { Children, New, OnEvent, PropertyTable } from "@rbxts/fusion";
+import { GameImages } from "shared/assets";
+import { BorderImage } from "../Image";
+import { GameImage } from "../Image/GameImage";
+import { RarityKey } from "shared/data";
+
+export interface GemSlotProps extends PropertyTable<ImageButton> {
+        Icon?: string;
+        Rarity?: RarityKey;
+        OnClick?: () => void;
+}
+
+export function GemSlot(props: GemSlotProps) {
+        const border = () => {
+                switch (props.Rarity) {
+                        case "Rare":
+                                return BorderImage.RareRarity();
+                        case "Epic":
+                                return BorderImage.EpicRarity();
+                        case "Legendary":
+                                return BorderImage.LegendaryRarity();
+                        default:
+                                return BorderImage.GothicMetal();
+                }
+        };
+        return New("ImageButton")({
+                Name: props.Name ?? "GemSlot",
+                Size: props.Size ?? UDim2.fromOffset(70, 70),
+                BackgroundTransparency: 1,
+                ImageTransparency: 1,
+                [OnEvent("Activated")]: () => props.OnClick && props.OnClick(),
+                [Children]: {
+                        Border: border(),
+                        Icon: GameImage({
+                                Image: props.Icon ?? GameImages.Gems.Colorable,
+                                Size: UDim2.fromScale(0.8, 0.8),
+                                Position: UDim2.fromScale(0.5, 0.5),
+                                AnchorPoint: new Vector2(0.5, 0.5),
+                        }),
+                },
+        });
+}

--- a/src/client/ui/atoms/Gem/RingSlot.ts
+++ b/src/client/ui/atoms/Gem/RingSlot.ts
@@ -1,0 +1,48 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        RingSlot.ts
+ * @module      RingSlot
+ * @layer       Client/UI/Atoms
+ * @description Circular drop slot used in the Gem Forge rings.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Codex
+ * @license      MIT
+ * @since        0.2.1
+ * @lastUpdated  2025-07-01 by Codex – Initial creation
+ *
+ * @dependencies
+ *   @rbxts/fusion ^0.4.0
+ */
+// #AGENT_ATOM
+import Fusion, { New, OnEvent, Value, Computed, PropertyTable, Children } from "@rbxts/fusion";
+import { GameImages } from "shared/assets";
+
+export interface RingSlotProps extends PropertyTable<ImageButton> {
+        Label?: string;
+        HighlightColor?: Color3;
+        OnDrop?: () => void;
+}
+
+export function RingSlot(props: RingSlotProps) {
+        const hovered = Value(false);
+        const highlight = Computed(() => (hovered.get() ? props.HighlightColor ?? new Color3(1, 1, 1) : new Color3(1, 1, 1)));
+        const transparency = Computed(() => (hovered.get() ? 0.4 : 0.8));
+        return New("ImageButton")({
+                Name: props.Name ?? "RingSlot",
+                BackgroundTransparency: 1,
+                Image: GameImages.TextureImage.Mystical, // #ASSETREQUEST - better ring art
+                ImageColor3: highlight,
+                ImageTransparency: transparency,
+                ScaleType: Enum.ScaleType.Fit,
+                Size: props.Size ?? UDim2.fromOffset(64, 64),
+                [OnEvent("MouseEnter")]: () => hovered.set(true),
+                [OnEvent("MouseLeave")]: () => hovered.set(false),
+                [Children]: {},
+        });
+}

--- a/src/client/ui/atoms/Gem/index.ts
+++ b/src/client/ui/atoms/Gem/index.ts
@@ -1,0 +1,2 @@
+export * from "./GemSlot";
+export * from "./RingSlot";

--- a/src/client/ui/atoms/index.ts
+++ b/src/client/ui/atoms/index.ts
@@ -24,3 +24,4 @@ export * from "./Button";
 export * from "./Container";
 export * from "./Image";
 export * from "./Text";
+export * from "./Gem";

--- a/src/client/ui/molecules/BarMeter.ts
+++ b/src/client/ui/molecules/BarMeter.ts
@@ -1,0 +1,52 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        BarMeter.ts
+ * @module      BarMeter
+ * @layer       Client/UI/Molecules
+ * @description Simple horizontal progress bar used for capacity meters.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Codex
+ * @license      MIT
+ * @since        0.2.1
+ * @lastUpdated  2025-07-01 by Codex – Initial creation
+ *
+ * @dependencies
+ *   @rbxts/fusion ^0.4.0
+ */
+
+import Fusion, { Children, New, Value, Computed } from "@rbxts/fusion";
+import { GamePanel } from "../atoms";
+
+export interface BarMeterProps {
+        value: Fusion.Value<number>;
+        max: Fusion.Value<number> | number;
+        Size?: UDim2;
+}
+
+export function BarMeter(props: BarMeterProps) {
+        const maxVal = typeOf(props.max) === "number" ? Value(props.max as number) : (props.max as Fusion.Value<number>);
+        const ratio = Computed(() => math.clamp(props.value.get() / maxVal.get(), 0, 1));
+
+        const fillSize = Computed(() => UDim2.fromScale(ratio.get(), 1));
+        const fill = New("Frame")({
+                Name: "Fill",
+                BackgroundColor3: Color3.fromRGB(120, 200, 120),
+                Size: fillSize,
+                BackgroundTransparency: 0.2,
+        });
+
+        return GamePanel({
+                Name: "BarMeter",
+                Size: props.Size ?? UDim2.fromOffset(200, 20),
+                BackgroundTransparency: 0.4,
+                Children: {
+                        Fill: fill,
+                },
+        });
+}

--- a/src/client/ui/molecules/index.ts
+++ b/src/client/ui/molecules/index.ts
@@ -1,0 +1,2 @@
+export * from "./AbilityInfoPanel";
+export * from "./BarMeter";

--- a/src/client/ui/organisms/InventoryGrid.ts
+++ b/src/client/ui/organisms/InventoryGrid.ts
@@ -7,14 +7,26 @@
  * @description Placeholder grid container for inventory slots.
  */
 
-import Fusion from "@rbxts/fusion";
-import { GamePanel } from "../atoms";
+import Fusion, { ForPairs } from "@rbxts/fusion";
+import { GamePanel, GemSlot } from "../atoms";
 import { Layout } from "../style";
+import { RarityKey } from "shared/data";
 
-export const InventoryGrid = () => {
-	return GamePanel({
-		Name: "InventoryGrid",
-		Layout: Layout.Grid(5, UDim2.fromOffset(48, 48)),
-		Children: {},
-	});
+export interface InventoryGridProps {
+        items: Map<string, { icon: string; rarity: RarityKey }>;
+}
+
+export const InventoryGrid = (props: InventoryGridProps) => {
+        return GamePanel({
+                Name: "InventoryGrid",
+                Scrolling: true,
+                Layout: Layout.Grid(5, UDim2.fromOffset(70, 70)),
+                Children: {
+                        Slots: ForPairs(props.items, (id, data) => $tuple(id, GemSlot({
+                                Name: `Slot-${id}`,
+                                Icon: data.icon,
+                                Rarity: data.rarity,
+                        }))),
+                },
+        });
 };

--- a/src/client/ui/screens/GemForgeScreen.ts
+++ b/src/client/ui/screens/GemForgeScreen.ts
@@ -1,38 +1,111 @@
+/// <reference types="@rbxts/types" />
+
 /**
  * @file        GemForgeScreen.ts
  * @module      GemForgeScreen
  * @layer       Client/UI/Screens
- * @description Screen for the Gem Forge UI, allowing players to combine and upgrade gems.
+ * @description UI screen for forging manifestation gems.
  *
  * ╭───────────────────────────────╮
  * │  Soul Steel · Coding Guide    │
  * │  Fusion v4 · Strict TS · ECS  │
  * ╰───────────────────────────────╯
  *
- * @author       Trembus
+ * @author       Codex
  * @license      MIT
  * @since        0.2.1
- * @lastUpdated  2025-05-29 by Trembus – Initial creation
+ * @lastUpdated  2025-07-01 by Codex – Reconstructed screen
  *
  * @dependencies
  *   @rbxts/fusion ^0.4.0
- *
  */
-import Fusion, { New, Children } from "@rbxts/fusion";
-import { GamePanel, BorderImage } from "../atoms";
+
+import Fusion, { Children, New, Value, Computed, OnEvent } from "@rbxts/fusion";
+import { Players } from "@rbxts/services";
+import { GamePanel, RingSlot } from "../atoms";
+import { InventoryGrid } from "../organisms";
+import { BarMeter } from "../molecules";
+import { Layout, Padding } from "../style";
+import { GameImages } from "shared/assets";
+import { RarityKey } from "shared/data";
 
 export const GemForgeScreen = () => {
-	return GamePanel({
-		Name: "GemForgeScreen",
-		Size: UDim2.fromScale(1, 1),
-		Children: {
-			ForgePanel: GamePanel({
-				Name: "ForgePanel",
-				Size: UDim2.fromScale(0.5, 0.5),
-				Position: UDim2.fromScale(0.5, 0.5),
-				AnchorPoint: new Vector2(0.5, 0.5),
-				BorderImage: BorderImage.GothicMetal(),
-			}),
-		},
-	});
+        const playerGui = Players.LocalPlayer.WaitForChild("PlayerGui");
+
+        // sample gem store for display
+        const gemStore = new Map<string, { icon: string; rarity: RarityKey }>();
+        gemStore.set("1", { icon: GameImages.Gems.Colorable, rarity: "Common" });
+        gemStore.set("2", { icon: GameImages.Gems.Colorable, rarity: "Rare" });
+        gemStore.set("3", { icon: GameImages.Gems.Colorable, rarity: "Epic" });
+
+        const capacity = Value(30);
+        const maxCapacity = Value(100);
+        const formFilled = Value(false);
+        const abilityFilled = Value(false);
+        const bonusFilled = Value(false);
+
+        const canForge = Computed(
+                () => formFilled.get() && abilityFilled.get() && bonusFilled.get() && capacity.get() <= maxCapacity.get(),
+        );
+
+        const screen = New("ScreenGui")({
+                Name: "GemForgeScreen",
+                Parent: playerGui,
+                ResetOnSpawn: false,
+                DisplayOrder: 1000,
+                Enabled: true,
+                [Children]: {
+                        MainFrame: GamePanel({
+                                Name: "ForgeMainFrame",
+                                Size: UDim2.fromOffset(800, 600),
+                                Position: UDim2.fromScale(0.5, 0.5),
+                                AnchorPoint: new Vector2(0.5, 0.5),
+                                Padding: Padding(6),
+                                Children: {
+                                        Layout: Layout.HorizontalSet(10),
+                                        Inventory: InventoryGrid({ items: gemStore }),
+                                        ForgeArea: GamePanel({
+                                                Name: "ForgeArea",
+                                                Size: UDim2.fromOffset(400, 400),
+                                                BackgroundTransparency: 1,
+                                                Children: {
+                                                        FormSlot: RingSlot({
+                                                                Name: "FormSlot",
+                                                                Size: UDim2.fromOffset(64, 64),
+                                                                Position: UDim2.fromOffset(308, 168),
+                                                        }),
+                                                        AbilitySlot: RingSlot({
+                                                                Name: "AbilitySlot",
+                                                                Size: UDim2.fromOffset(64, 64),
+                                                                Position: UDim2.fromOffset(98, 289),
+                                                        }),
+                                                        BonusSlot: RingSlot({
+                                                                Name: "BonusSlot",
+                                                                Size: UDim2.fromOffset(64, 64),
+                                                                Position: UDim2.fromOffset(98, 47),
+                                                        }),
+                                                },
+                                        }),
+                                        Preview: GamePanel({
+                                                Name: "Preview",
+                                                Size: UDim2.fromOffset(220, 350),
+                                                BackgroundTransparency: 0.2,
+                                        }),
+                                        Meter: BarMeter({ value: capacity, max: maxCapacity, Size: UDim2.fromOffset(300, 20) }),
+                                        ConfirmButton: New("TextButton")({
+                                                Name: "ConfirmButton",
+                                                Text: "FORGE",
+                                                Size: UDim2.fromOffset(150, 40),
+                                                AnchorPoint: new Vector2(0.5, 0),
+                                                Position: UDim2.fromScale(0.5, 1),
+                                                BackgroundColor3: Color3.fromRGB(60, 60, 60),
+                                                TextColor3: Color3.fromRGB(255, 255, 255),
+                                                [OnEvent("Activated")]: () => print("Forge sent"),
+                                                Active: canForge,
+                                        }),
+                                },
+                        }),
+                },
+        });
+        return screen;
 };


### PR DESCRIPTION
## Summary
- add new Gem atom components (GemSlot, RingSlot)
- add BarMeter molecule
- revamp InventoryGrid to render gem slots
- build new GemForgeScreen layout
- update barrel exports and development summary

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685b11f3321c8327bc85570e6d07ed40