### PR TITLE
Add HUD screen and countdown timer

### DIFF
--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -14,7 +14,9 @@ The table below lists core modules grouped by network layer and their current st
 |Client|`client/stylesheet.client.ts`|Under Construction|StyleSheet prototype|
 |Client|`client/ui/atoms`|Usable|Core UI atoms (buttons, panels)|
 |Client|`client/ui/style`|Rock Solid|Tokenized layout and colors|
-|Client|`client/ui/screens`|Under Construction|Gem forge screen basic layout|
+|Client|`client/ui/atoms/Screen/GameScreen.ts`|Usable|Base screen wrapper|
+|Client|`client/ui/molecules/CountdownTimer.ts`|Usable|Displays battle countdown|
+|Client|`client/ui/screens`|Under Construction|Gem forge and HUD screens|
 |Server|`server/main.server.ts`|Under Construction|Joins players and loads profiles|
 |Server|`server/network/network.server.ts`|Usable|Server network handlers|
 |Server|`server/services/ProfileService.ts`|Under Construction|Loads player profiles|

--- a/src/client/main.client.ts
+++ b/src/client/main.client.ts
@@ -24,7 +24,7 @@
 import { Children, New } from "@rbxts/fusion";
 import { Players } from "@rbxts/services";
 import { GameImages } from "shared/assets/image";
-import { GamePanel, BorderImage, GameImage, Padding, ResourceBars, IconButton, GameTextScreen, GemForgeScreen } from "./ui";
+import { GamePanel, BorderImage, GameImage, Padding, ResourceBars, IconButton, GameTextScreen, GemForgeScreen, PlayerHUDScreen } from "./ui";
 import { EventButtons } from "./ui/organisms/EventButtons";
 import { AbilityInfoPanel } from "./ui/molecules/AbilityInfoPanel";
 import { OrganismTestingScreen } from "./ui/screens/OrganismScreen";
@@ -63,4 +63,5 @@ const ScreenGUI = New("ScreenGui")({
 GameTextScreen();
 OrganismTestingScreen();
 GemForgeScreen();
+PlayerHUDScreen();
 ScreenGUI.Enabled = true; // Enable the GUI

--- a/src/client/ui/atoms/Screen/GameScreen.ts
+++ b/src/client/ui/atoms/Screen/GameScreen.ts
@@ -1,0 +1,46 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        GameScreen.ts
+ * @module      GameScreen
+ * @layer       Client/UI/Atoms
+ * @description Base ScreenGui container with standard defaults.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Codex
+ * @license      MIT
+ * @since        0.2.1
+ * @lastUpdated  2025-07-02 by Codex – Initial creation
+ *
+ * @dependencies
+ *   @rbxts/fusion ^0.4.0
+ */
+// #AGENT_ATOM
+
+import Fusion, { Children, New, PropertyTable } from "@rbxts/fusion";
+import { Players } from "@rbxts/services";
+
+export interface GameScreenProps extends PropertyTable<ScreenGui> {
+        Children?: Fusion.ChildrenValue;
+}
+
+export const GameScreen = (props: GameScreenProps) => {
+        props.Name = props.Name ?? "GameScreen";
+        props.DisplayOrder = props.DisplayOrder ?? 1000;
+        props.ResetOnSpawn = props.ResetOnSpawn ?? false;
+        props.Enabled = props.Enabled ?? true;
+        const parent = props.Parent ?? Players.LocalPlayer.WaitForChild("PlayerGui");
+
+        return New("ScreenGui")({
+                Name: props.Name,
+                DisplayOrder: props.DisplayOrder,
+                ResetOnSpawn: props.ResetOnSpawn,
+                Enabled: props.Enabled,
+                Parent: parent,
+                [Children]: props.Children ?? {},
+        });
+};

--- a/src/client/ui/atoms/Screen/index.ts
+++ b/src/client/ui/atoms/Screen/index.ts
@@ -1,0 +1,1 @@
+export * from "./GameScreen";

--- a/src/client/ui/atoms/index.ts
+++ b/src/client/ui/atoms/index.ts
@@ -25,3 +25,4 @@ export * from "./Container";
 export * from "./Image";
 export * from "./Text";
 export * from "./Gem";
+export * from "./Screen";

--- a/src/client/ui/molecules/CountdownTimer.ts
+++ b/src/client/ui/molecules/CountdownTimer.ts
@@ -1,0 +1,37 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        CountdownTimer.ts
+ * @module      CountdownTimer
+ * @layer       Client/UI/Molecules
+ * @description Displays a stylized countdown value for battle rooms.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Codex
+ * @license      MIT
+ * @since        0.2.1
+ * @lastUpdated  2025-07-02 by Codex – Initial creation
+ *
+ * @dependencies
+ *   @rbxts/fusion ^0.4.0
+ */
+
+import Fusion, { Computed, Value } from "@rbxts/fusion";
+import { GameText } from "../atoms";
+
+export interface CountdownTimerProps {
+        remaining: Fusion.Value<number>;
+}
+
+export function CountdownTimer(props: CountdownTimerProps) {
+        const text = Computed(() => `Battle starts in: ${props.remaining.get()}s`);
+        return GameText({
+                Name: "CountdownTimer",
+                Text: text,
+                TextSize: 28,
+        });
+}

--- a/src/client/ui/molecules/index.ts
+++ b/src/client/ui/molecules/index.ts
@@ -1,2 +1,3 @@
 export * from "./AbilityInfoPanel";
 export * from "./BarMeter";
+export * from "./CountdownTimer";

--- a/src/client/ui/screens/PlayerHUDScreen.ts
+++ b/src/client/ui/screens/PlayerHUDScreen.ts
@@ -1,0 +1,36 @@
+import Fusion, { Children, Value } from "@rbxts/fusion";
+import { Network } from "shared/network";
+import { GamePanel, GameScreen } from "../atoms";
+import { ResourceBars } from "../organisms";
+import { CountdownTimer } from "../molecules";
+
+export const PlayerHUDScreen = () => {
+        const remaining = Value(0);
+        const CountdownEvent = Network.Client.Get("RoomCountdown");
+        CountdownEvent.Connect((_roomId, time) => remaining.set(time));
+
+        return GameScreen({
+                Name: "PlayerHUDScreen",
+                Children: {
+                        ResourceContainer: GamePanel({
+                                Name: "ResourceContainer",
+                                BackgroundTransparency: 1,
+                                Size: UDim2.fromOffset(250, 100),
+                                Position: UDim2.fromOffset(20, 20),
+                                Children: {
+                                        Bars: ResourceBars(),
+                                },
+                        }),
+                        Countdown: GamePanel({
+                                Name: "CountdownPanel",
+                                BackgroundTransparency: 1,
+                                AnchorPoint: new Vector2(0.5, 0),
+                                Position: UDim2.fromScale(0.5, 0),
+                                Size: UDim2.fromOffset(200, 50),
+                                Children: {
+                                        Timer: CountdownTimer({ remaining }),
+                                },
+                        }),
+                },
+        });
+};

--- a/src/client/ui/screens/index.ts
+++ b/src/client/ui/screens/index.ts
@@ -1,2 +1,3 @@
 export * from "./GemForgeScreen";
 export * from "./GameTextScreen";
+export * from "./PlayerHUDScreen";


### PR DESCRIPTION
## Summary
- create GameScreen atom to reuse ScreenGui setup
- implement CountdownTimer molecule for BattleRoom countdowns
- add PlayerHUDScreen that shows resources and timer
- expose new components from barrel files
- update client entry to create PlayerHUDScreen
- maintain AGENTS development summary

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685b19df5b9883279fec5e9363fc5a2c