### PR TITLE
Implement fusion-based theme tokens

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -23,9 +23,15 @@
 					}
 				}
 			},
-			"TS": {
-				"$path": "out/shared"
-			}
+                        "TS": {
+                                "$path": "out/shared"
+                        },
+                        "Theme": {
+                                "$path": "out/theme"
+                        },
+                        "Constants": {
+                                "$path": "out/constants"
+                        }
 		},
 		"StarterPlayer": {
 			"$className": "StarterPlayer",

--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -10,6 +10,8 @@ The table below lists core modules grouped by network layer and their current st
 |Shared|`shared/data/rarity.ts`|Stub|Placeholder rarity enums|
 |Shared|`shared/assets`|Usable|Image asset constants|
 |Shared|`shared/states`|Usable|Signal-based shared state|
+|Shared|`theme`|Usable|Fusion theme store|
+|Shared|`constants`|Rock Solid|Sizes and asset ids|
 |Client|`client/main.client.ts`|Usable|Entry point and UI bootstrap|
 |Client|`client/stylesheet.client.ts`|Under Construction|StyleSheet prototype|
 |Client|`client/ui/atoms`|Usable|Core UI atoms (buttons, panels)|

--- a/src/client/ui/atoms/Button/GameButton.ts
+++ b/src/client/ui/atoms/Button/GameButton.ts
@@ -23,6 +23,7 @@
 import Fusion, { Children, OnEvent, PropertyTable } from "@rbxts/fusion";
 import { GamePanel } from "../Container";
 import { GameImage } from "../Image";
+import { useToken } from "theme/hooks";
 
 export interface GameButtonProps extends PropertyTable<ImageButton> {
 	OnClick?: () => void;
@@ -30,12 +31,13 @@ export interface GameButtonProps extends PropertyTable<ImageButton> {
 }
 
 export function GameButton(props: GameButtonProps) {
-	const SelectedState = Fusion.Value<boolean>(props.Selected ?? false);
-	return GamePanel({
-		Name: props.Name,
-		Size: props.Size ?? UDim2.fromOffset(100, 50),
-		BackgroundColor3: new Color3(0.2, 0.2, 0.2),
-		BorderSizePixel: 0,
+        const SelectedState = Fusion.Value<boolean>(props.Selected ?? false);
+        const bg = useToken("panelBg");
+        return GamePanel({
+                Name: props.Name,
+                Size: props.Size ?? UDim2.fromOffset(100, 50),
+                BackgroundColor3: bg,
+                BorderSizePixel: 0,
 		Children: {
 			ButtonImage: Fusion.New("ImageButton")({
 				Name: "ButtonImage",

--- a/src/client/ui/atoms/Button/ItemButton.ts
+++ b/src/client/ui/atoms/Button/ItemButton.ts
@@ -27,6 +27,7 @@ import { BorderImage, GameImage } from "../Image";
 import { ButtonSizes } from "client/ui/tokens";
 import { GameImages } from "shared/assets";
 import { GameText } from "../Text";
+import { useToken } from "theme/hooks";
 
 const sampleItemMetadata = {
 	DisplayName: "Sample Item",
@@ -50,13 +51,16 @@ export function ItemButton(itemId?: string) {
 				return BorderImage.GothicMetal();
 		}
 	}).get();
-	const button = New("ImageButton")({
-		Name: "GridItemButton",
-		BackgroundTransparency: 0.2,
-		BackgroundColor3: Color3.fromRGB(50, 50, 50),
-		BorderSizePixel: 0,
-		Image: borderImage.Image,
-		Size: UDim2.fromScale(1, 1),
+        const bg = useToken("panelBg");
+        const textColor = useToken("textPrimary");
+
+        const button = New("ImageButton")({
+                Name: "GridItemButton",
+                BackgroundTransparency: 0.2,
+                BackgroundColor3: bg,
+                BorderSizePixel: 0,
+                Image: borderImage.Image,
+                Size: UDim2.fromScale(1, 1),
 		[OnEvent("Activated")]: () => {
 			if (itemMetadata.OnClick) {
 				itemMetadata.OnClick();
@@ -69,15 +73,15 @@ export function ItemButton(itemId?: string) {
 				Position: UDim2.fromScale(0.5, 0.5),
 				AnchorPoint: new Vector2(0.5, 0.5),
 			}),
-			displayName: GameText({
-				Name: "DisplayName",
-				Text: itemMetadata.DisplayName,
-				TextColor3: Color3.fromRGB(255, 255, 255),
-				TextSize: 14,
-				Size: UDim2.fromScale(1, 0.2),
-				Position: UDim2.fromScale(0, 0.8),
-				BackgroundTransparency: 1,
-			}),
+                        displayName: GameText({
+                                Name: "DisplayName",
+                                Text: itemMetadata.DisplayName,
+                                TextColor3: textColor,
+                                TextSize: 14,
+                                Size: UDim2.fromScale(1, 0.2),
+                                Position: UDim2.fromScale(0, 0.8),
+                                BackgroundTransparency: 1,
+                        }),
 		},
 	});
 

--- a/src/client/ui/atoms/Container/GamePanel.ts
+++ b/src/client/ui/atoms/Container/GamePanel.ts
@@ -23,7 +23,7 @@
 
 import Fusion, { New, Children, Computed, Value, OnEvent, PropertyTable } from "@rbxts/fusion";
 import { Layout, Stroke } from "../../tokens";
-import { PanelBackgroundColors } from "client/ui/tokens/color";
+import { useToken } from "theme/hooks";
 /* =============================================== GamePanel Props ========================================= */
 export interface GamePanelProps extends PropertyTable<Frame> {
 	BorderImage?: ImageLabel; // Optional border image for the panel
@@ -42,19 +42,20 @@ export interface GamePanelProps extends PropertyTable<Frame> {
 
 /* =============================================== Scroll Component ========================================= */
 function ScrollContent(children: Fusion.ChildrenValue, layout?: UIListLayout | UIGridLayout) {
-	return New("ScrollingFrame")({
-		Name: "ScrollContent",
-		BackgroundTransparency: 0.8,
-		BackgroundColor3: PanelBackgroundColors.RobotTheme.BackgroundColor,
-		Size: UDim2.fromScale(1, 1),
-		Position: UDim2.fromScale(0, 0),
-		ScrollBarThickness: 2,
-		ScrollBarImageTransparency: 0.5,
-		[Children]: {
-			Layout: layout ?? Layout.Grid(10, UDim2.fromOffset(100, 100)),
-			...children,
-		},
-	});
+        const bg = useToken("panelBg");
+        return New("ScrollingFrame")({
+                Name: "ScrollContent",
+                BackgroundTransparency: 0.8,
+                BackgroundColor3: bg,
+                Size: UDim2.fromScale(1, 1),
+                Position: UDim2.fromScale(0, 0),
+                ScrollBarThickness: 2,
+                ScrollBarImageTransparency: 0.5,
+                [Children]: {
+                        Layout: layout ?? Layout.Grid(10, UDim2.fromOffset(100, 100)),
+                        ...children,
+                },
+        });
 }
 
 /* =============================================== Content Component ========================================= */
@@ -73,16 +74,18 @@ function Content(children: Fusion.ChildrenValue, layout?: UIListLayout | UIGridL
 
 /* =============================================== GamePanel Component ========================================= */
 export const GamePanel = (props: GamePanelProps) => {
-	/* ----- State Setup ----- */
-	// Hover State
-	const isHovered = Value(false);
+        /* ----- State Setup ----- */
+        // Hover State
+        const isHovered = Value(false);
+        const bg = useToken("panelBg");
+        const borderColor = useToken("panelBorder");
 
 	// UI Stroke Hover Effect
-	const strokeColor = Computed(() => {
-		return isHovered.get() && props.HoverEffect
-			? PanelBackgroundColors.RobotTheme.BackgroundColor
-			: PanelBackgroundColors.RobotTheme.BackgroundColor;
-	});
+        const strokeColor = Computed(() => {
+                return isHovered.get() && props.HoverEffect
+                        ? borderColor.get()
+                        : borderColor.get();
+        });
 
 	// Stroke Thickness
 	const strokeThickness = Computed(() => {
@@ -98,7 +101,7 @@ export const GamePanel = (props: GamePanelProps) => {
 	/* -- Frame Properties -- */
 	props.Name = props.Name ?? "GamePanel";
 	props.AnchorPoint = props.AnchorPoint ?? new Vector2(0, 0);
-	props.BackgroundColor3 = props.BackgroundColor3 ?? PanelBackgroundColors.RobotTheme.BackgroundColor;
+        props.BackgroundColor3 = props.BackgroundColor3 ?? bg;
 	props.BackgroundTransparency = props.BackgroundTransparency ?? 0.2;
 	props.Position = props.Position ?? UDim2.fromScale(0, 0);
 	props.Size = props.Size ?? UDim2.fromScale(1, 1);

--- a/src/client/ui/atoms/Text/GameText.ts
+++ b/src/client/ui/atoms/Text/GameText.ts
@@ -1,5 +1,5 @@
 import Fusion, { Computed, OnEvent, Value } from "@rbxts/fusion";
-import { PlayerTheme, RobotTheme, TextSizes } from "client/ui/tokens";
+import { useToken, useFont } from "theme/hooks";
 
 export interface GameTextProps extends Fusion.PropertyTable<TextLabel> {
 	ShadowBox?: boolean;
@@ -7,20 +7,24 @@ export interface GameTextProps extends Fusion.PropertyTable<TextLabel> {
 }
 
 export function GameText(props: GameTextProps): TextLabel {
-	const HoveredState = Value(false);
-	const TextValue = Value(props.Text ?? "Default Text");
+        const HoveredState = Value(false);
+        const TextValue = Value(props.Text ?? "Default Text");
+        const colour = useToken("textPrimary");
+        const font = useFont();
 
-	const GameTextComponent = Fusion.New("TextLabel")({
-		Name: props.Name ?? "GameText",
-		AnchorPoint: props.AnchorPoint ?? new Vector2(0.5, 0.5),
-		Position: props.Position ?? UDim2.fromScale(0.5, 0.5),
-		Size: props.Size ?? UDim2.fromScale(0.5, 0.5),
+        const GameTextComponent = Fusion.New("TextLabel")({
+                Name: props.Name ?? "GameText",
+                AnchorPoint: props.AnchorPoint ?? new Vector2(0.5, 0.5),
+                Position: props.Position ?? UDim2.fromScale(0.5, 0.5),
+                Size: props.Size ?? UDim2.fromScale(0.5, 0.5),
+                TextColor3: colour,
+                Font: Computed(() => font.get().family),
 
-		/* TextStroke properties */
-		//...TextStrokeProps,
-		[OnEvent("MouseEnter")]: () => HoveredState.set(true),
-		[OnEvent("MouseLeave")]: () => HoveredState.set(false),
-	});
+                /* TextStroke properties */
+                //...TextStrokeProps,
+                [OnEvent("MouseEnter")]: () => HoveredState.set(true),
+                [OnEvent("MouseLeave")]: () => HoveredState.set(false),
+        });
 
 	return GameTextComponent;
 }

--- a/src/client/ui/molecules/BarMeter.ts
+++ b/src/client/ui/molecules/BarMeter.ts
@@ -22,6 +22,7 @@
 
 import Fusion, { Children, New, Value, Computed } from "@rbxts/fusion";
 import { BorderImage, GamePanel } from "../atoms";
+import { useToken } from "theme/hooks";
 
 export interface BarMeterProps {
 	value: Fusion.Value<number>;
@@ -31,16 +32,18 @@ export interface BarMeterProps {
 }
 
 export function BarMeter(props: BarMeterProps) {
-	const maxVal = typeOf(props.max) === "number" ? Value(props.max as number) : (props.max as Fusion.Value<number>);
-	const ratio = Computed(() => math.clamp(props.value.get() / maxVal.get(), 0, 1));
+        const maxVal = typeOf(props.max) === "number" ? Value(props.max as number) : (props.max as Fusion.Value<number>);
+        const ratio = Computed(() => math.clamp(props.value.get() / maxVal.get(), 0, 1));
+
+        const defaultColor = useToken("textPrimary");
 
 	const fillSize = Computed(() => UDim2.fromScale(ratio.get(), 1));
-	const fill = New("Frame")({
-		Name: "Fill",
-		BackgroundColor3: props.color ?? Color3.fromRGB(0, 255, 0), // Default to green if no color is provided
-		Size: fillSize,
-		BackgroundTransparency: 0.2,
-	});
+        const fill = New("Frame")({
+                Name: "Fill",
+                BackgroundColor3: props.color ?? defaultColor,
+                Size: fillSize,
+                BackgroundTransparency: 0.2,
+        });
 
 	return GamePanel({
 		Name: "BarMeter",

--- a/src/constants/AssetIds.ts
+++ b/src/constants/AssetIds.ts
@@ -1,0 +1,18 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        AssetIds.ts
+ * @module      AssetIds
+ * @layer       Shared
+ * @description Asset id constants shared across themes.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ */
+
+export const AssetIds = {
+    clickAudio: "rbxassetid://0987654321",
+    logoTexture: "rbxassetid://1122334455",
+};

--- a/src/constants/Sizes.ts
+++ b/src/constants/Sizes.ts
@@ -1,0 +1,19 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        Sizes.ts
+ * @module      Sizes
+ * @layer       Shared
+ * @description Cross-theme numeric constants.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ */
+
+export const Sizes = {
+    panelWidth: 320,
+    panelHeight: 200,
+    gutter: 12,
+};

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,11 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        index.ts
+ * @module      ConstantsIndex
+ * @layer       Shared
+ * @description Barrel file exporting shared constants.
+ */
+
+export * from "./Sizes";
+export * from "./AssetIds";

--- a/src/theme/ThemeKey.ts
+++ b/src/theme/ThemeKey.ts
@@ -1,0 +1,22 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        ThemeKey.ts
+ * @module      ThemeKey
+ * @layer       Shared
+ * @description Enumeration of available themes.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ */
+
+/* =============================================== Theme Enumeration ======================= */
+
+export enum ThemeKey {
+    CyberGothic = "CyberGothic",
+    SolarDrift = "SolarDrift",
+}
+
+export const DEFAULT_THEME = ThemeKey.CyberGothic;

--- a/src/theme/ThemeState.ts
+++ b/src/theme/ThemeState.ts
@@ -1,0 +1,36 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        ThemeState.ts
+ * @module      ThemeState
+ * @layer       Client
+ * @description Reactive theme store powered by Fusion.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ */
+
+import Fusion from "@rbxts/fusion";
+import { ThemeKey, DEFAULT_THEME } from "./ThemeKey";
+import { cyberGothic } from "./tokens/cyberGothic";
+import { solarDrift } from "./tokens/solarDrift";
+import { ThemeTokens } from "./types";
+
+const { Value, Computed } = Fusion;
+
+const themeKey = Value<ThemeKey>(DEFAULT_THEME);
+
+const themeMap: Record<ThemeKey, ThemeTokens> = {
+    [ThemeKey.CyberGothic]: cyberGothic,
+    [ThemeKey.SolarDrift]: solarDrift,
+};
+
+const currentTokens = Computed(() => themeMap[themeKey.get()]);
+
+export const ThemeState = {
+    set: (key: ThemeKey) => themeKey.set(key),
+    key: themeKey,
+    tokens: currentTokens,
+};

--- a/src/theme/hooks.ts
+++ b/src/theme/hooks.ts
@@ -1,0 +1,31 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        hooks.ts
+ * @module      ThemeHooks
+ * @layer       Client
+ * @description Helper hooks for consuming theme tokens.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ */
+
+import Fusion from "@rbxts/fusion";
+import { ThemeState } from "./ThemeState";
+import { ColourTokens, FontTokens, ImageTokens } from "./types";
+
+const { Computed } = Fusion;
+
+export function useToken<K extends keyof ColourTokens>(key: K): Fusion.Computed<Color3> {
+    return Computed(() => ThemeState.tokens.get().colours[key]);
+}
+
+export function useFont(): Fusion.Computed<FontTokens> {
+    return Computed(() => ThemeState.tokens.get().fonts);
+}
+
+export function useImage<K extends keyof ImageTokens>(key: K): Fusion.Computed<string> {
+    return Computed(() => ThemeState.tokens.get().images[key]);
+}

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,5 @@
+export * from "./ThemeKey";
+export * from "./ThemeState";
+export * from "./hooks";
+export * from "./tokens";
+export * from "./types";

--- a/src/theme/tokens/base.ts
+++ b/src/theme/tokens/base.ts
@@ -1,0 +1,17 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        base.ts
+ * @module      BaseTokens
+ * @layer       Shared
+ * @description Global tokens that never vary between themes.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ */
+
+/* =============================================== Base Tokens ============================ */
+
+export const base = {};

--- a/src/theme/tokens/cyberGothic.ts
+++ b/src/theme/tokens/cyberGothic.ts
@@ -1,0 +1,35 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        cyberGothic.ts
+ * @module      CyberGothicTokens
+ * @layer       Shared
+ * @description Token table for the CyberGothic theme.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ */
+
+import { ThemeTokens } from "../types";
+import { Sizes } from "../../constants/Sizes";
+
+/* =============================================== Token Table ============================= */
+
+export const cyberGothic: ThemeTokens = {
+    colours: {
+        panelBg: Color3.fromRGB(16, 16, 16),
+        panelBorder: Color3.fromRGB(0, 255, 153),
+        textPrimary: Color3.fromRGB(0, 255, 153),
+        textSecondary: Color3.fromRGB(179, 255, 230),
+    },
+    fonts: {
+        family: Enum.Font.Arcade,
+        weightNormal: 400,
+        weightBold: 700,
+    },
+    images: {
+        panelBorderSlice: "rbxassetid://1234567890",
+    },
+};

--- a/src/theme/tokens/index.ts
+++ b/src/theme/tokens/index.ts
@@ -1,0 +1,3 @@
+export * from "./base";
+export * from "./cyberGothic";
+export * from "./solarDrift";

--- a/src/theme/tokens/solarDrift.ts
+++ b/src/theme/tokens/solarDrift.ts
@@ -1,0 +1,35 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        solarDrift.ts
+ * @module      SolarDriftTokens
+ * @layer       Shared
+ * @description Example token table for the SolarDrift theme.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ */
+
+import { ThemeTokens } from "../types";
+import { Sizes } from "../../constants/Sizes";
+
+/* =============================================== Token Table ============================= */
+
+export const solarDrift: ThemeTokens = {
+    colours: {
+        panelBg: Color3.fromRGB(28, 12, 40),
+        panelBorder: Color3.fromRGB(255, 175, 0),
+        textPrimary: Color3.fromRGB(255, 175, 0),
+        textSecondary: Color3.fromRGB(255, 226, 179),
+    },
+    fonts: {
+        family: Enum.Font.SciFi,
+        weightNormal: 400,
+        weightBold: 700,
+    },
+    images: {
+        panelBorderSlice: "rbxassetid://9876543210",
+    },
+};

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -1,0 +1,38 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        types.ts
+ * @module      ThemeTypes
+ * @layer       Shared
+ * @description Type contracts for theme design tokens.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ */
+
+/* =============================================== Token Groups ============================ */
+
+export interface ColourTokens {
+    panelBg: Color3;
+    panelBorder: Color3;
+    textPrimary: Color3;
+    textSecondary: Color3;
+}
+
+export interface FontTokens {
+    family: Enum.Font;
+    weightNormal: number;
+    weightBold: number;
+}
+
+export interface ImageTokens {
+    panelBorderSlice: string;
+}
+
+export type ThemeTokens = {
+    colours: ColourTokens;
+    fonts: FontTokens;
+    images: ImageTokens;
+};


### PR DESCRIPTION
## Summary
- scaffold token and constants folders
- add CyberGothic theme with token contracts
- implement reactive `ThemeState` and helper hooks
- refactor core atoms and BarMeter to consume tokens
- expose constants and update development summary

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c0fe176308327a888ef44af2ef9f5