### PR TITLE
Add GameWindow molecule with TitleBar

### DIFF
--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -18,6 +18,8 @@ The table below lists core modules grouped by network layer and their current st
 |Client|`client/ui/style`|Rock Solid|Tokenized layout and colors|
 |Client|`client/ui/atoms/Screen/GameScreen.ts`|Usable|Base screen wrapper|
 |Client|`client/ui/molecules/CountdownTimer.ts`|Usable|Displays battle countdown|
+|Client|`client/ui/molecules/GameWindow.ts`|Usable|Panel window with title bar|
+|Client|`client/ui/molecules/TitleBar.ts`|Usable|Window title bar component|
 |Client|`client/ui/screens`|Under Construction|Gem forge and HUD screens|
 |Server|`server/main.server.ts`|Under Construction|Joins players and loads profiles|
 |Server|`server/network/network.server.ts`|Usable|Server network handlers|

--- a/src/client/ui/molecules/GameWindow.ts
+++ b/src/client/ui/molecules/GameWindow.ts
@@ -1,0 +1,61 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        GameWindow.ts
+ * @module      GameWindow
+ * @layer       Client/UI/Molecules
+ * @description Panel-based window component with a title bar.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Codex
+ * @license      MIT
+ * @since        0.2.1
+ * @lastUpdated  2025-07-02 by Codex – Initial creation
+ *
+ * @dependencies
+ *   @rbxts/fusion ^0.4.0
+ */
+
+import Fusion, { Children, Computed } from "@rbxts/fusion";
+import { GamePanel } from "../atoms";
+import { TitleBar } from "./TitleBar";
+
+export interface GameWindowProps extends Fusion.PropertyTable<Frame> {
+	Title?: string;
+	VisibleState: Fusion.Value<boolean>;
+	Children?: Fusion.ChildrenValue;
+}
+
+export function GameWindow(props: GameWindowProps) {
+	props.Name = props.Name ?? "GameWindow";
+	props.Size = props.Size ?? UDim2.fromOffset(300, 200);
+	props.AnchorPoint = props.AnchorPoint ?? new Vector2(0.5, 0.5);
+	props.Position = props.Position ?? UDim2.fromScale(0.5, 0.5);
+
+	const content = GamePanel({
+		Name: "WindowContent",
+		BackgroundTransparency: 1,
+		Size: UDim2.fromScale(1, 0.9),
+		Position: UDim2.fromScale(0, 0.1),
+		Children: props.Children ?? {},
+	});
+
+	return GamePanel({
+		Name: props.Name,
+		Size: props.Size,
+		Position: props.Position,
+		AnchorPoint: props.AnchorPoint,
+		Visible: props.VisibleState,
+		Children: {
+			TitleBar: TitleBar({
+				Title: props.Title ?? "Window",
+				VisibleState: props.VisibleState,
+			}),
+			Content: content,
+		},
+	});
+}

--- a/src/client/ui/molecules/TitleBar.ts
+++ b/src/client/ui/molecules/TitleBar.ts
@@ -1,0 +1,59 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        TitleBar.ts
+ * @module      TitleBar
+ * @layer       Client/UI/Molecules
+ * @description Simple title bar with a close button.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Codex
+ * @license      MIT
+ * @since        0.2.1
+ * @lastUpdated  2025-07-02 by Codex – Initial creation
+ *
+ * @dependencies
+ *   @rbxts/fusion ^0.4.0
+ */
+
+import Fusion, { Children, New, Value } from "@rbxts/fusion";
+import { GamePanel, GameText, GameButton } from "../atoms";
+import { Layout } from "../tokens";
+import { GameImages } from "shared/assets";
+
+export interface TitleBarProps {
+	Title: string;
+	VisibleState: Fusion.Value<boolean>;
+}
+
+export function TitleBar(props: TitleBarProps) {
+	const titleText = GameText({
+		Name: "WindowTitle",
+		Text: props.Title,
+		Size: UDim2.fromScale(0.9, 1),
+		AnchorPoint: new Vector2(0, 0.5),
+		Position: UDim2.fromScale(0, 0.5),
+	});
+
+	const closeBtn = GameButton({
+		Name: "CloseButton",
+		Size: UDim2.fromOffset(20, 20),
+		Image: GameImages.Control.Close,
+		OnClick: () => props.VisibleState.set(false),
+	});
+
+	return GamePanel({
+		Name: "TitleBar",
+		Size: UDim2.fromScale(1, 0.1),
+		BackgroundTransparency: 0.3,
+		Layout: Layout.HorizontalSet(2),
+		Children: {
+			TitleText: titleText,
+			Close: closeBtn,
+		},
+	});
+}

--- a/src/client/ui/molecules/index.ts
+++ b/src/client/ui/molecules/index.ts
@@ -1,3 +1,5 @@
 export * from "./AbilityInfoPanel";
 export * from "./BarMeter";
 export * from "./CountdownTimer";
+export * from "./TitleBar";
+export * from "./GameWindow";


### PR DESCRIPTION
## Summary
- implement `TitleBar` with close button
- add `GameWindow` molecule that toggles visibility via state
- export new molecules and document them in the dev summary

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685c237ba2448327a252113d3c464ceb