### PR TITLE
Add TSDoc headers for draggable atoms

### DIFF
--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -17,6 +17,8 @@ The table below lists core modules grouped by network layer and their current st
 |Client|`client/ui/atoms`|Usable|Core UI atoms (buttons, panels)|
 |Client|`client/ui/style`|Rock Solid|Tokenized layout and colors|
 |Client|`client/ui/atoms/Screen/GameScreen.ts`|Usable|Base screen wrapper|
+|Client|`client/ui/atoms/DragDetector/DragDetector.ts`|Usable|Drag detector atom|
+|Client|`client/ui/atoms/Button/DraggableButton.ts`|Usable|Draggable button using DragDetector|
 |Client|`client/ui/molecules/CountdownTimer.ts`|Usable|Displays battle countdown|
 |Client|`client/ui/molecules/GameWindow.ts`|Usable|Panel window with title bar|
 |Client|`client/ui/molecules/TitleBar.ts`|Usable|Window title bar component|

--- a/src/client/ui/atoms/Button/DraggableButton.ts
+++ b/src/client/ui/atoms/Button/DraggableButton.ts
@@ -1,3 +1,25 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        DraggableButton.ts
+ * @module      DraggableButton
+ * @layer       Client/UI/Atoms
+ * @description Button component that can be dragged using a `DragDetector`.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Trembus
+ * @license      MIT
+ * @since        0.2.1
+ * @lastUpdated  2025-07-03 by Codex – Added documentation header
+ *
+ * @dependencies
+ *   @rbxts/fusion ^0.4.0
+ */
+
 import Fusion, { Children, New, Value } from "@rbxts/fusion";
 import { DragDetector, DragDetectorProps } from "../DragDetector"; // your existing DragDetector component
 import { GameButton } from "./GameButton"; // your existing visual atom

--- a/src/client/ui/atoms/DragDetector/DragDetector.ts
+++ b/src/client/ui/atoms/DragDetector/DragDetector.ts
@@ -1,4 +1,25 @@
-// DragDetector.ts
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        DragDetector.ts
+ * @module      DragDetector
+ * @layer       Client/UI/Atoms
+ * @description Wrapper component for `UIDragDetector` with typed events.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Trembus
+ * @license      MIT
+ * @since        0.2.1
+ * @lastUpdated  2025-07-03 by Codex – Added documentation header
+ *
+ * @dependencies
+ *   @rbxts/fusion ^0.4.0
+ */
+
 import { New, OnEvent, Children, PropertyTable } from "@rbxts/fusion";
 
 export interface DragDetectorEvents {


### PR DESCRIPTION
## Summary
- document DraggableButton atom
- document DragDetector atom
- track new atoms in AGENTS_DEVELOPMENT_SUMMARY

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685d1d4610f08327a9209efba99ea51a