### PR TITLE
Fix DraggableButton ghost visibility

### DIFF
--- a/src/client/ui/atoms/Button/DraggableButton.ts
+++ b/src/client/ui/atoms/Button/DraggableButton.ts
@@ -20,16 +20,16 @@ export function DraggableButton(props: DraggableButtonProps) {
 				/* ——— EVENTS ——— */
 				OnDragStart: (pos) => {
 					print(`Drag started at: ${pos.X}, ${pos.Y}`);
-					if (props.Ghost === undefined) return;
+                                        if (props.Ghost === undefined) return;
 
-					button.Visible = false;
-					const g = button.Clone() as ImageButton;
-					g.Name = `${button.Name}_Ghost`;
-					g.AnchorPoint = new Vector2(0.5, 0.5);
-					g.Position = UDim2.fromOffset(pos.X, pos.Y);
-					g.ZIndex += 1000;
-					g.Parent = button.FindFirstAncestorWhichIsA("ScreenGui");
-					ghostRef.set(g);
+                                        const g = button.Clone() as ImageButton;
+                                        g.Name = `${button.Name}_Ghost`;
+                                        g.AnchorPoint = new Vector2(0.5, 0.5);
+                                        g.Position = UDim2.fromOffset(pos.X, pos.Y);
+                                        g.ZIndex += 1000;
+                                        g.Parent = button.FindFirstAncestorWhichIsA("ScreenGui");
+                                        button.Visible = false;
+                                        ghostRef.set(g);
 				},
 				OnDragContinue: (pos) => {
 					const g = ghostRef.get();


### PR DESCRIPTION
## Summary
- adjust drag start logic so the ghost clone is initialized before hiding the button

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685d1d3e1c3c8327b52bd365ecbf11df