### PR TITLE
Improve HUD code readability and docs

### DIFF
--- a/src/client/ui/molecules/Button/HUDMenuButton.ts
+++ b/src/client/ui/molecules/Button/HUDMenuButton.ts
@@ -1,12 +1,31 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        HUDMenuButton.ts
+ * @module      HUDMenuButton
+ * @layer       Client/UI/Molecules/Button
+ * @description Toggle button used in the HUD menu bar to show or hide screens.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @since        0.2.1
+ * @lastUpdated  2025-07-05 by Codex – Documentation cleanup
+ */
+
 import Fusion, { Children, Computed, New, OnEvent, Value } from "@rbxts/fusion";
 import { GameImage } from "client/ui/atoms";
 import { GameImages, MenuButtonImageMap, ScreenKey, ScreenState, ShowScreen } from "shared";
 
-export interface ToggleMenuProps extends Fusion.PropertyTable<ImageButton> {
-	ScreenKey: ScreenKey;
+export interface HUDMenuButtonProps extends Fusion.PropertyTable<ImageButton> {
+        /** Which screen this button toggles. */
+        ScreenKey: ScreenKey;
 }
 
-export const StateToggleButton = (props: ToggleMenuProps) => {
+/* =============================== HUDMenuButton Component ====================== */
+export const HUDMenuButton = (props: HUDMenuButtonProps) => {
 	const SelectedState = ScreenState[props.ScreenKey] ?? Value(false);
 	const Hovered = Value(false);
 

--- a/src/client/ui/molecules/Button/index.ts
+++ b/src/client/ui/molecules/Button/index.ts
@@ -1,0 +1,10 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        src/ui/molecules/Button/index.ts
+ * @module      MoleculeButtonsIndex
+ * @layer       Client/UI/Molecules
+ * @description Barrel file exporting button molecules.
+ */
+
+export * from "./HUDMenuButton";

--- a/src/client/ui/molecules/index.ts
+++ b/src/client/ui/molecules/index.ts
@@ -2,3 +2,4 @@ export * from "./AbilityInfoPanel";
 export * from "./FillBar/BarMeter";
 export * from "./CountdownTimer";
 export * from "./GameWindow";
+export * from "./Button";

--- a/src/client/ui/organisms/HUDMenuBar.ts
+++ b/src/client/ui/organisms/HUDMenuBar.ts
@@ -1,21 +1,30 @@
-import { BorderImage, GamePanel } from "../atoms";
-import { StateToggleButton } from "../molecules/Button/StateToggleButton";
-import Fusion, { Children, ForPairs, ForValues, New } from "@rbxts/fusion";
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        HUDMenuBar.ts
+ * @module      HUDMenuBar
+ * @layer       Client/Organisms
+ * @description Horizontal container of HUD menu buttons.
+ */
+
+import { GamePanel } from "../atoms";
+import { HUDMenuButton } from "../molecules/Button";
+import Fusion, { ForValues } from "@rbxts/fusion";
 import { Layout } from "../tokens";
-import { GameImages, MenuButtonImageMap, ScreenKey, ScreenOrder, ScreenState } from "shared";
+import { GameImages, MenuButtonImageMap, ScreenKey, ScreenOrder } from "shared";
 
 export interface HudMenuBarProps {
 	ScreenStateKeys: ScreenKey[];
 }
 
 export const HUDMenuBar = (props: HudMenuBarProps) => {
-	const HUDMenuButtons = ForValues(props.ScreenStateKeys, (value) => {
-		return StateToggleButton({
-			ScreenKey: value,
-			Name: `${value}Button`,
-			LayoutOrder: ScreenOrder[value] ?? 0,
-			Image: MenuButtonImageMap[value] ?? GameImages.MenuButtonImage,
-		});
+        const HUDMenuButtons = ForValues(props.ScreenStateKeys, (value) => {
+                return HUDMenuButton({
+                        ScreenKey: value,
+                        Name: `${value}Button`,
+                        LayoutOrder: ScreenOrder[value] ?? 0,
+                        Image: MenuButtonImageMap[value] ?? GameImages.MenuButtonImage,
+                });
 	});
 	const container = GamePanel({
 		Name: "HUDMenuBar",

--- a/src/client/ui/organisms/index.ts
+++ b/src/client/ui/organisms/index.ts
@@ -2,3 +2,4 @@ export * from "./ResourceBars";
 export * from "./InventoryGrid";
 export * from "./EventButtons";
 export * from "./CharacterInfoCard";
+export * from "./HUDMenuBar";

--- a/src/client/ui/screens/PlayerHUDScreen.ts
+++ b/src/client/ui/screens/PlayerHUDScreen.ts
@@ -1,3 +1,12 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        PlayerHUDScreen.ts
+ * @module      PlayerHUDScreen
+ * @layer       Client/UI/Screens
+ * @description Primary heads-up display shown during gameplay.
+ */
+
 import { SCREEN_KEYS } from "shared";
 import { GameScreen } from "../atoms";
 import { HUDMenuBar } from "../organisms/HUDMenuBar";

--- a/src/shared/assets/image.ts
+++ b/src/shared/assets/image.ts
@@ -59,12 +59,13 @@ export const GameImages = {
 		EpicSet: "rbxassetid://135166624307221",
 		LegendarySet: "rbxassetid://85570068018789",
 	},
-	Control: {
-		Increment: "rbxassetid://102421835119714",
-		Decrement: "rbxassetid://78091115085992",
-		Close: "rbxassetid://91437543746962",
-		TrippleArrow: "rbxassetid://136693752293641",
-	},
+        /* Buttons and UI controls */
+        Control: {
+                Increment: "rbxassetid://102421835119714",
+                Decrement: "rbxassetid://78091115085992",
+                Close: "rbxassetid://91437543746962",
+                TripleArrow: "rbxassetid://136693752293641",
+        },
 	Currency: {
 		Coins: "rbxassetid://127745571044516",
 		Shards: "rbxassetid://73893872719367",

--- a/src/shared/states/ScreenState.ts
+++ b/src/shared/states/ScreenState.ts
@@ -15,7 +15,18 @@
 
 import { Value } from "@rbxts/fusion";
 
-export const SCREEN_KEYS = ["Settings", "Inventory", "Character", "Quests", "Shop", "Teleport", "GemForge"] as const;
+/**
+ * Ordered list of all HUD-related screen keys.
+ */
+export const SCREEN_KEYS = [
+        "Settings",
+        "Inventory",
+        "Character",
+        "Quests",
+        "Shop",
+        "Teleport",
+        "GemForge",
+] as const;
 
 export type ScreenKey = (typeof SCREEN_KEYS)[number];
 export type ScreenMap = Record<ScreenKey, Value<boolean>>;
@@ -41,12 +52,13 @@ export const ScreenOrder: ScreenOrder = {
 	GemForge: 7,
 } satisfies ScreenOrder;
 
+/**
+ * Sets the given screen to visible while hiding all others.
+ *
+ * @param key - Screen to show.
+ */
 export function ShowScreen(key: ScreenKey) {
-	for (const screenKey of SCREEN_KEYS) {
-		if (screenKey !== key) {
-			ScreenState[screenKey].set(false);
-		} else {
-			ScreenState[screenKey].set(true);
-		}
-	}
+        for (const screenKey of SCREEN_KEYS) {
+                ScreenState[screenKey].set(screenKey === key);
+        }
 }


### PR DESCRIPTION
## Summary
- document HUDMenuBar, HUDMenuButton and PlayerHUDScreen
- add HUDMenuButton and barrel file
- fix unused imports in HUDMenuBar
- export HUDMenuBar and HUDMenuButton via indexes
- tweak ScreenState docs and simplify ShowScreen
- correct `TripleArrow` asset constant

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685d62c6f0808327bcface5a4d465ff4