### PR TITLE
Add docs for new screen stubs

### DIFF
--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -22,8 +22,13 @@ The table below lists core modules grouped by network layer and their current st
 |Client|`client/ui/molecules/CountdownTimer.ts`|Usable|Displays battle countdown|
 |Client|`client/ui/molecules/GameWindow.ts`|Usable|Panel window with title bar|
 |Client|`client/ui/molecules/TitleBar.ts`|Usable|Window title bar component|
-|Client|`client/ui/screens`|Under Construction|Gem forge and HUD screens|
+|Client|`client/ui/screens`|Under Construction|Gem forge, character, inventory, shop, settings, teleport and HUD screens|
 |Client|`client/ui/screens/DragDropScreen.ts`|Usable|Drag and drop demo|
+|Client|`client/ui/screens/CharacterScreen.ts`|Stub|Character info window|
+|Client|`client/ui/screens/InventoryScreen.ts`|Stub|Inventory window|
+|Client|`client/ui/screens/ShopScreen.ts`|Stub|Item shop window|
+|Client|`client/ui/screens/SettingsScreen.ts`|Stub|Settings window|
+|Client|`client/ui/screens/TeleportScreen.ts`|Stub|Teleport locations window|
 |Server|`server/main.server.ts`|Under Construction|Joins players and loads profiles|
 |Server|`server/network/network.server.ts`|Usable|Server network handlers|
 |Server|`server/services/ProfileService.ts`|Under Construction|Loads player profiles|

--- a/src/client/ui/screens/CharacterScreen.ts
+++ b/src/client/ui/screens/CharacterScreen.ts
@@ -1,4 +1,26 @@
-import { GameWindow, GameWindowProps } from "../molecules";
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        CharacterScreen.ts
+ * @module      CharacterScreen
+ * @layer       Client/UI/Screens
+ * @description UI screen for viewing the player's character details.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Codex
+ * @license      MIT
+ * @since        0.2.1
+ * @lastUpdated  2025-07-01 by Codex – Initial stub
+ *
+ * @dependencies
+ *   @rbxts/fusion ^0.4.0
+ */
+
+import { GameWindow } from "../molecules";
 
 export const CharacterScreen = () => {
 	return GameWindow({

--- a/src/client/ui/screens/InventoryScreen.ts
+++ b/src/client/ui/screens/InventoryScreen.ts
@@ -1,3 +1,25 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        InventoryScreen.ts
+ * @module      InventoryScreen
+ * @layer       Client/UI/Screens
+ * @description UI screen for managing the player's inventory.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Codex
+ * @license      MIT
+ * @since        0.2.1
+ * @lastUpdated  2025-07-01 by Codex – Initial stub
+ *
+ * @dependencies
+ *   @rbxts/fusion ^0.4.0
+ */
+
 import { GameWindow } from "../molecules";
 export const InventoryScreen = () => {
 	return GameWindow({

--- a/src/client/ui/screens/SettingsScreen.ts
+++ b/src/client/ui/screens/SettingsScreen.ts
@@ -1,4 +1,26 @@
-import { GameWindow, GameWindowProps } from "../molecules";
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        SettingsScreen.ts
+ * @module      SettingsScreen
+ * @layer       Client/UI/Screens
+ * @description UI screen for adjusting player settings.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Codex
+ * @license      MIT
+ * @since        0.2.1
+ * @lastUpdated  2025-07-01 by Codex – Initial stub
+ *
+ * @dependencies
+ *   @rbxts/fusion ^0.4.0
+ */
+
+import { GameWindow } from "../molecules";
 
 export const SettingsScreen = () => {
 	return GameWindow({

--- a/src/client/ui/screens/ShopScreen.ts
+++ b/src/client/ui/screens/ShopScreen.ts
@@ -1,3 +1,25 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        ShopScreen.ts
+ * @module      ShopScreen
+ * @layer       Client/UI/Screens
+ * @description UI screen for purchasing items from the shop.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Codex
+ * @license      MIT
+ * @since        0.2.1
+ * @lastUpdated  2025-07-01 by Codex – Initial stub
+ *
+ * @dependencies
+ *   @rbxts/fusion ^0.4.0
+ */
+
 import { GameWindow } from "../molecules";
 
 export const ShopScreen = () => {

--- a/src/client/ui/screens/TeleportScreen.ts
+++ b/src/client/ui/screens/TeleportScreen.ts
@@ -1,4 +1,26 @@
-import { GameWindow, GameWindowProps } from "../molecules";
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        TeleportScreen.ts
+ * @module      TeleportScreen
+ * @layer       Client/UI/Screens
+ * @description UI screen for teleporting to different locations.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Codex
+ * @license      MIT
+ * @since        0.2.1
+ * @lastUpdated  2025-07-01 by Codex – Initial stub
+ *
+ * @dependencies
+ *   @rbxts/fusion ^0.4.0
+ */
+
+import { GameWindow } from "../molecules";
 
 export const TeleportScreen = () => {
 	return GameWindow({

--- a/src/client/ui/screens/index.ts
+++ b/src/client/ui/screens/index.ts
@@ -1,2 +1,7 @@
 export * from "./GemForgeScreen";
 export * from "./PlayerHUDScreen";
+export * from "./CharacterScreen";
+export * from "./InventoryScreen";
+export * from "./ShopScreen";
+export * from "./SettingsScreen";
+export * from "./TeleportScreen";


### PR DESCRIPTION
## Summary
- document Character, Inventory, Shop, Settings and Teleport screens
- export all screens via barrel file
- update development summary for new screen stubs

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685d7044d9dc8327b485bec5b0b9c897