### PR TITLE
Implement unified UIButton primitive

### DIFF
--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -24,7 +24,8 @@ The table below lists core modules grouped by network layer and their current st
 |Client|`client/ui/style`|Rock Solid|Tokenized layout and colors|
 |Client|`client/ui/atoms/Screen/GameScreen.ts`|Usable|Base screen wrapper|
 |Client|`client/ui/atoms/DragDetector/DragDetector.ts`|Usable|Drag detector atom|
-|Client|`client/ui/atoms/Button/DraggableButton.ts`|Usable|Draggable button using DragDetector|
+|Client|`client/ui/atoms/Button/UIButton.ts`|Usable|Unified button primitive|
+|Client|`client/ui/atoms/Button/DraggableButton.ts`|Usable|Wrapper preset for draggable buttons|
 |Client|`client/ui/molecules/CountdownTimer.ts`|Usable|Displays battle countdown|
 |Client|`client/ui/molecules/GameWindow.ts`|Usable|Panel window with title bar|
 |Client|`client/ui/molecules/TitleBar.ts`|Usable|Window title bar component|

--- a/src/client/ui/atoms/Button/DraggableButton.ts
+++ b/src/client/ui/atoms/Button/DraggableButton.ts
@@ -4,62 +4,20 @@
  * @file        DraggableButton.ts
  * @module      DraggableButton
  * @layer       Client/UI/Atoms
- * @description Button component that can be dragged using a `DragDetector`.
- *
- * ╭───────────────────────────────╮
- * │  Soul Steel · Coding Guide    │
- * │  Fusion v4 · Strict TS · ECS  │
- * ╰───────────────────────────────╯
- *
- * @author       Trembus
- * @license      MIT
- * @since        0.2.1
- * @lastUpdated  2025-07-03 by Codex – Added documentation header
- *
- * @dependencies
- *   @rbxts/fusion ^0.4.0
+ * @description Thin wrapper around `UIButton` with drag enabled.
  */
 
-import Fusion, { Children, OnEvent, PropertyTable } from "@rbxts/fusion";
+import { UIButton, UIButtonProps } from "./UIButton";
 
-export interface DraggableButtonProps extends PropertyTable<ImageButton> {
-	OnClick?: () => void;
-	OnDragStart?: (pos: Vector2) => void;
-	OnDragContinue?: (pos: Vector2) => void;
-	OnDragEnd?: (pos: Vector2) => void;
+export interface DraggableButtonProps extends Partial<UIButtonProps> {
+    Image?: string;
 }
 
-export function DraggableButton(props: DraggableButtonProps) {
-	const dragButton = Fusion.New("ImageButton")({
-		Name: props.Name ?? "DraggableButton",
-		Size: props.Size ?? UDim2.fromOffset(100, 50),
-		BackgroundTransparency: 0.9,
-		ImageTransparency: 1,
-		[OnEvent("Activated")]: props.OnClick,
-		[Children]: {
-			Image: Fusion.New("ImageLabel")({
-				Name: "ButtonImage",
-				ImageTransparency: 1,
-				Size: UDim2.fromScale(1, 1),
-				BackgroundTransparency: 1,
-				Image: props.Image ?? "rbxassetid://121566852339881",
-			}),
-			DragDetector: Fusion.New("UIDragDetector")({
-				Name: "DragDetector",
-				Enabled: true,
-				DragRelativity: Enum.UIDragDetectorDragRelativity.Absolute,
-				DragStyle: Enum.UIDragDetectorDragStyle.Scriptable,
-				[OnEvent("DragStart")]: (pos) => {
-					props.OnDragStart?.(pos);
-				},
-				[OnEvent("DragContinue")]: (pos) => {
-					props.OnDragContinue?.(pos);
-				},
-				[OnEvent("DragEnd")]: (pos) => {
-					props.OnDragEnd?.(pos);
-				},
-			}),
-		},
-	});
-	return dragButton;
-}
+export const DraggableButton = (p: DraggableButtonProps) => {
+    const icon = p.Icon ?? p.Image;
+    const props: Partial<UIButtonProps> = { ...p };
+    delete (props as Partial<DraggableButtonProps>).Image;
+    delete props.Icon;
+    return UIButton({ Draggable: true, Variant: "flat", Icon: icon, ...props });
+};
+

--- a/src/client/ui/atoms/Button/GameButton.ts
+++ b/src/client/ui/atoms/Button/GameButton.ts
@@ -4,60 +4,20 @@
  * @file        GameButton.ts
  * @module      GameButton
  * @layer       Client/UI/Atoms
- * @description Simple button component built from `GamePanel` and `GameImage`.
- *
- * ╭───────────────────────────────╮
- * │  Soul Steel · Coding Guide    │
- * │  Fusion v4 · Strict TS · ECS  │
- * ╰───────────────────────────────╯
- *
- * @author       Trembus
- * @license      MIT
- * @since        0.2.0
- * @lastUpdated  2025-06-25 by Luminesa – Added documentation header
- *
- * @dependencies
- *   @rbxts/fusion ^0.4.0
+ * @description Panel-style button wrapper around `UIButton`.
  */
 
-import Fusion, { Children, OnEvent, PropertyTable } from "@rbxts/fusion";
-import { GamePanel } from "../Container";
-import { GameImage } from "../Image";
-import { useToken } from "theme/hooks";
+import { UIButton, UIButtonProps } from "./UIButton";
 
-export interface GameButtonProps extends PropertyTable<ImageButton> {
-	OnClick?: () => void;
-	Selected?: boolean;
+export interface GameButtonProps extends Partial<UIButtonProps> {
+    Image?: string; // backward compatibility
 }
 
-export function GameButton(props: GameButtonProps) {
-	const SelectedState = Fusion.Value<boolean>(props.Selected ?? false);
-	const bg = useToken("panelBg");
-	return GamePanel({
-		Name: props.Name,
-		Size: props.Size ?? UDim2.fromOffset(50, 50),
-		Position: props.Position ?? UDim2.fromScale(0, 0),
-		AnchorPoint: props.AnchorPoint ?? new Vector2(0, 0),
-		BackgroundTransparency: props.BackgroundTransparency ?? 0.2,
-		BackgroundColor3: bg,
-		BorderSizePixel: 0,
-		Content: {
-			ButtonImage: Fusion.New("ImageButton")({
-				Name: "ButtonImage",
-				ImageTransparency: 1,
-				Size: UDim2.fromScale(1, 1),
-				BackgroundTransparency: 1,
-				[OnEvent("Activated")]: () => {
-					props.OnClick?.();
-				},
-				[Children]: {
-					Image: GameImage({
-						Name: "ButtonImage",
-						RatioConstraint: 1,
-						Image: props.Image ?? "rbxassetid://121566852339881",
-					}),
-				},
-			}),
-		},
-	});
-}
+export const GameButton = (p: GameButtonProps) => {
+    const icon = p.Icon ?? p.Image;
+    const props: Partial<UIButtonProps> = { ...p };
+    delete (props as Partial<GameButtonProps>).Image;
+    delete props.Icon;
+    return UIButton({ Icon: icon, Variant: "panel", ...props });
+};
+

--- a/src/client/ui/atoms/Button/IconButton.ts
+++ b/src/client/ui/atoms/Button/IconButton.ts
@@ -4,53 +4,21 @@
  * @file        IconButton.ts
  * @module      IconButton
  * @layer       Client/UI/Atoms
- * @description Simple icon button component.
- *
- * ╭───────────────────────────────╮
- * │  Soul Steel · Coding Guide    │
- * │  Fusion v4 · Strict TS · ECS  │
- * ╰───────────────────────────────╯
- *
- * @author       Trembus
- * @license      MIT
- * @since        0.2.0
- * @lastUpdated  2025-06-25 by Trembus – Initial creation
+ * @description Thin icon button wrapper around `UIButton`.
  */
 
-/* =============================================== Imports =============================================== */
-import Fusion from "@rbxts/fusion";
-import { ButtonSizes } from "client/ui/tokens";
-import { GameImages, GameImageSubKey } from "shared/assets/image";
-/* =============================================== Props =============================================== */
+import { UIButton, UIButtonProps } from "./UIButton";
 
-export interface IconButtonProps {
-	Icon: string;
-	Size?: UDim2;
-	Position?: UDim2;
-	AnchorPoint?: Vector2;
-	OnClick?: () => void;
+export interface IconButtonProps extends Partial<UIButtonProps> {
+    Icon: string;
+    Image?: string;
 }
 
-/* =============================================== IconButton Component =============================================== */
-export const IconButton = (props: IconButtonProps) => {
-	const { Icon, Size, Position, AnchorPoint, OnClick } = props;
-
-	return Fusion.New("ImageButton")({
-		Name: "IconButton",
-		Image: GameImages[Icon as GameImageSubKey] ?? Icon,
-		Size: Size ?? ButtonSizes.Icon(),
-		Position: Position ?? UDim2.fromScale(0, 0),
-		AnchorPoint: AnchorPoint ?? new Vector2(0.5, 0.5),
-		BackgroundTransparency: 1,
-		ImageColor3: new Color3(1, 1, 1),
-		ImageTransparency: 0,
-		[Fusion.OnEvent("Activated")]: () => {
-			if (OnClick) {
-				OnClick();
-			} else {
-				print("IconButton clicked, but no OnClick handler provided.");
-			}
-			return;
-		},
-	});
+export const IconButton = (p: IconButtonProps) => {
+    const icon = p.Icon ?? p.Image;
+    const props: Partial<UIButtonProps> = { ...p };
+    delete (props as Partial<IconButtonProps>).Image;
+    delete props.Icon;
+    return UIButton({ Icon: icon, Variant: "flat", ...props });
 };
+

--- a/src/client/ui/atoms/Button/ItemButton.ts
+++ b/src/client/ui/atoms/Button/ItemButton.ts
@@ -4,96 +4,31 @@
  * @file        ItemButton.ts
  * @module      ItemButton
  * @layer       Client/UI/Atoms
- * @description Clickable inventory item button with rarity border and icon.
- *
- * ╭───────────────────────────────╮
- * │  Soul Steel · Coding Guide    │
- * │  Fusion v4 · Strict TS · ECS  │
- * ╰───────────────────────────────╯
- *
- * @author       Trembus
- * @license      MIT
- * @since        0.2.1
- * @lastUpdated  2025-06-25 by Luminesa – Added documentation header
- *
- * @dependencies
- *   @rbxts/fusion ^0.4.0
+ * @description Inventory item button wrapper using `UIButton`.
  */
 
-import { RarityKey } from "shared";
-import { GamePanel, GamePanelProps } from "../Container/GamePanel";
-import { Computed, ChildrenValue, New, Children, OnEvent, Value } from "@rbxts/fusion";
-import { BorderImage, GameImage } from "../Image";
-import { ButtonSizes } from "client/ui/tokens";
-import { GameImages } from "shared/assets";
-import { GameText } from "../Text";
-import { useToken } from "theme/hooks";
+import { RarityKey } from "shared/data/RarityData";
+import { UIButton } from "./UIButton";
 
 const sampleItemMetadata = {
-	DisplayName: "Sample Item",
-	Rarity: "Common" as RarityKey,
-	itemId: "sample-item-123",
-	Icon: "rbxassetid://124443221759409", // Replace with actual icon ID
-	OnClick: () => {
-		print("Item clicked: " + sampleItemMetadata.itemId);
-	},
+    DisplayName: "Sample Item",
+    Rarity: "Common" as RarityKey,
+    itemId: "sample-item-123",
+    Icon: "rbxassetid://124443221759409",
+    OnClick: () => {
+        print(`Item clicked: ${sampleItemMetadata.itemId}`);
+    },
 };
 
-export function ItemButton(itemId?: string) {
-	const itemMetadata = sampleItemMetadata; // Replace with actual item metadata retrieval logic
-	const borderImage = Computed(() => {
-		switch (itemMetadata.Rarity) {
-			case "Common":
-				return BorderImage.GothicMetal();
-			case "Rare":
-				return BorderImage.RareRarity();
-			default:
-				return BorderImage.GothicMetal();
-		}
-	}).get();
-	const bg = useToken("panelBg");
-	const textColor = useToken("textPrimary");
+export const ItemButton = (id?: string) => {
+    const meta = sampleItemMetadata; // placeholder until real lookup
+    return UIButton({
+        Icon: meta.Icon,
+        Label: meta.DisplayName,
+        Rarity: meta.Rarity,
+        Variant: "panel",
+        Draggable: true,
+        OnClick: meta.OnClick,
+    });
+};
 
-	const button = New("ImageButton")({
-		Name: "GridItemButton",
-		BackgroundTransparency: 0.2,
-		BackgroundColor3: bg,
-		BorderSizePixel: 0,
-		Image: borderImage.Image,
-		Size: UDim2.fromScale(1, 1),
-		[OnEvent("Activated")]: () => {
-			if (itemMetadata.OnClick) {
-				itemMetadata.OnClick();
-			}
-		},
-		[Children]: {
-			iconImage: GameImage({
-				Image: itemMetadata.Icon,
-				Size: UDim2.fromScale(0.8, 0.8),
-				Position: UDim2.fromScale(0.5, 0.5),
-				AnchorPoint: new Vector2(0.5, 0.5),
-			}),
-			displayName: GameText({
-				Name: "DisplayName",
-				TextStateValue: Value(itemMetadata.DisplayName),
-				TextColor3: textColor,
-				TextSize: 14,
-				Size: UDim2.fromScale(1, 0.2),
-				Position: UDim2.fromScale(0, 0.8),
-				BackgroundTransparency: 1,
-			}),
-		},
-	});
-
-	const container = GamePanel({
-		Name: "ItemButtonContainer",
-		Size: ButtonSizes.GridButton(),
-		BackgroundTransparency: 1,
-		DragEnabled: true,
-		Content: {
-			ImageButton: button,
-		},
-	});
-
-	return container;
-}

--- a/src/client/ui/atoms/Button/UIButton.ts
+++ b/src/client/ui/atoms/Button/UIButton.ts
@@ -1,0 +1,143 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        UIButton.ts
+ * @module      UIButton
+ * @layer       Client/UI/Atoms
+ * @description Unified button primitive used by all button wrappers.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ */
+
+// -------------- Imports ------------- //
+import Fusion, { Children, Computed, New, OnEvent, PropertyTable, Value } from "@rbxts/fusion";
+import { GamePanel } from "../Container";
+import { GameText } from "../Text";
+import { BorderImage } from "../Image";
+import { GameImages } from "shared/assets";
+import { RarityKey } from "shared/data/RarityData";
+import { ButtonSizes } from "shared/constants/sizes";
+import { useToken } from "theme/hooks";
+
+// -------------- Helpers -------------- //
+function resolveIcon(icon?: string): string {
+    if (!icon) return "";
+    const lookup = (GameImages as unknown as Record<string, string>)[icon];
+    return lookup ?? icon;
+}
+
+function resolveBorder(rarity?: RarityKey) {
+    if (!rarity) return undefined;
+    switch (rarity) {
+        case "Common":
+            return BorderImage.CommonRarity();
+        case "Uncommon":
+            return BorderImage.CommonRarity();
+        case "Rare":
+            return BorderImage.RareRarity();
+        case "Epic":
+            return BorderImage.EpicRarity();
+        case "Legendary":
+            return BorderImage.LegendaryRarity();
+    }
+}
+
+// -------------- Props ---------------- //
+export interface UIButtonProps extends PropertyTable<ImageButton> {
+    /** Main icon – raw asset id or GameImages key */
+    Icon?: string;
+    /** Optional rarity key → resolves to BorderImage */
+    Rarity?: RarityKey;
+    /** Optional label under the icon */
+    Label?: string;
+    /** Show as panel-style (token background) or flat */
+    Variant?: "flat" | "panel";
+    /** Interactive flags */
+    Draggable?: boolean;
+    Selected?: boolean;
+
+    /* Event handlers */
+    OnClick?: () => void;
+    OnDragStart?: (pos: Vector2) => void;
+    OnDragContinue?: (pos: Vector2) => void;
+    OnDragEnd?: (pos: Vector2) => void;
+}
+
+// -------------- UIButton Component --------------- //
+export const UIButton = (props: UIButtonProps) => {
+    const variant = props.Variant ?? "flat";
+    const selected = Value(props.Selected ?? false);
+    const bg = useToken("panelBg");
+    const borderColour = useToken("panelBorder");
+
+    const background = Computed(() => (selected.get() ? borderColour.get() : bg.get()));
+    const borderTransparency = Computed(() => (selected.get() ? 0 : 1));
+
+    const drag = props.Draggable
+        ? New("UIDragDetector")({
+                Name: "DragDetector",
+                Enabled: true,
+                DragRelativity: Enum.UIDragDetectorDragRelativity.Absolute,
+                DragStyle: Enum.UIDragDetectorDragStyle.Scriptable,
+                [OnEvent("DragStart")]: props.OnDragStart,
+                [OnEvent("DragContinue")]: props.OnDragContinue,
+                [OnEvent("DragEnd")]: props.OnDragEnd,
+          })
+        : undefined;
+
+    const button = New("ImageButton")({
+        Name: props.Name ?? "UIButton",
+        Size: props.Size ?? ButtonSizes.Icon(),
+        AnchorPoint: props.AnchorPoint ?? new Vector2(0.5, 0.5),
+        Position: props.Position ?? UDim2.fromScale(0.5, 0.5),
+        BackgroundTransparency: variant === "flat" ? 1 : props.BackgroundTransparency ?? 0,
+        BackgroundColor3: variant === "panel" ? background : props.BackgroundColor3 ?? new Color3(1, 1, 1),
+        Image: resolveIcon(props.Icon),
+        ImageColor3: props.ImageColor3 ?? new Color3(1, 1, 1),
+        [OnEvent("Activated")]: () => props.OnClick && props.OnClick(),
+        [Children]: {
+            Label: props.Label
+                ? GameText({
+                        Name: "Label",
+                        TextStateValue: Value(props.Label),
+                        AnchorPoint: new Vector2(0.5, 1),
+                        Position: UDim2.fromScale(0.5, 1),
+                        Size: UDim2.fromScale(1, 0.25),
+                        BackgroundTransparency: 1,
+                        TextSize: 14,
+                  })
+                : undefined,
+            Border: props.Rarity
+                ? (() => {
+                        const b = resolveBorder(props.Rarity!);
+                        if (b) {
+                            b.AnchorPoint = new Vector2(0.5, 0.5);
+                            b.Position = UDim2.fromScale(0.5, 0.5);
+                            b.Size = UDim2.fromScale(1, 1);
+                            (b as unknown as ImageLabel & { ImageTransparency: number }).ImageTransparency = borderTransparency as unknown as number;
+                        }
+                        return b;
+                  })()
+                : undefined,
+            Drag: variant === "flat" ? drag : undefined,
+        },
+    });
+
+    if (variant === "panel") {
+        return GamePanel({
+            Name: `${props.Name ?? "UIButton"}Panel`,
+            Size: props.Size ?? ButtonSizes.Icon(),
+            BackgroundTransparency: 0.2,
+            Content: {
+                Button: button,
+                Drag: drag,
+            },
+        });
+    }
+
+    return button;
+};
+

--- a/src/client/ui/atoms/Button/index.ts
+++ b/src/client/ui/atoms/Button/index.ts
@@ -7,7 +7,9 @@
  * @description Barrel export for button atoms.
  */
 
+export * from "./UIButton";
 export * from "./DraggableButton";
+export * from "./GameButton";
 export * from "./IconButton";
 export * from "./ItemButton";
-export * from "./GameButton";
+


### PR DESCRIPTION
## Summary
- add `UIButton` primitive and unify props
- refactor `GameButton`, `IconButton`, `DraggableButton`, and `ItemButton` as thin wrappers
- export new button APIs via barrel
- update development summary

## Testing
- `npm run build`
- `npm run lint` *(shows warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685fd16d8da08327a46182219f948874