### PR TITLE
Add Settings system and SettingListItem molecule

### DIFF
--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -29,6 +29,8 @@ The table below lists core modules grouped by network layer and their current st
 |Client|`client/ui/molecules/CountdownTimer.ts`|Usable|Displays battle countdown|
 |Client|`client/ui/molecules/GameWindow.ts`|Usable|Panel window with title bar|
 |Client|`client/ui/molecules/TitleBar.ts`|Usable|Window title bar component|
+|Client|`client/ui/molecules/SettingListItem.ts`|Usable|Displays and edits a single setting|
+|Client|`client/states/SettingsState.ts`|Usable|Reactive settings container|
 |Client|`client/ui/screens`|Under Construction|Gem forge, character, inventory, shop, settings, teleport and HUD screens|
 |Client|`client/ui/screens/DragDropScreen.ts`|Usable|Drag and drop demo|
 |Client|`client/ui/screens/CharacterScreen.ts`|Stub|Character info window|
@@ -40,6 +42,7 @@ The table below lists core modules grouped by network layer and their current st
 |Server|`server/network/network.server.ts`|Usable|Server network handlers|
 |Server|`server/services/ProfileService.ts`|Under Construction|Loads player profiles|
 |Server|`server/services/BattleRoomService.ts`|Stub|Matchmaking and teleport skeleton|
+|Server|`server/services/SettingsService.ts`|Usable|Stores player settings|
 |Server|`server/entity/Manifestation.ts`|Stub|Placeholder creation logic|
 |Server|`server/entity/npc/NPC.ts`|Usable|Basic NPC class|
 |Server|`server/entity/player/SoulPlayer.ts`|Usable|Player data container|

--- a/src/client/network/CallServer.ts
+++ b/src/client/network/CallServer.ts
@@ -1,16 +1,26 @@
 import { Players } from "@rbxts/services";
-import { AbilityKey, Network } from "shared";
+import { AbilityKey, Network, SettingKey, PlayerSettings } from "shared";
 
 /* Event Signals */
 const ActivateAbilitySignal = Network.Client.Get("ActivateAbility");
+const UpdateSettingSignal = Network.Client.Get("UpdatePlayerSetting");
 
 /* Function Signals */
 const GetPlayerAbilitiesSignal = Network.Client.Get("GetPlayerAbilities");
+const GetPlayerSettingsSignal = Network.Client.Get("GetPlayerSettings");
 
 export async function GetPlayerAbilities(): Promise<AbilityKey[] | undefined> {
 	return await GetPlayerAbilitiesSignal.CallServerAsync(Players.LocalPlayer);
 }
 
 export function ActivateAbility(abilityKey: AbilityKey): void {
-	ActivateAbilitySignal.SendToServer(abilityKey);
+        ActivateAbilitySignal.SendToServer(abilityKey);
+}
+
+export async function GetPlayerSettings(): Promise<PlayerSettings> {
+        return await GetPlayerSettingsSignal.CallServerAsync(Players.LocalPlayer);
+}
+
+export function UpdatePlayerSetting(key: SettingKey, value: boolean | string): void {
+        UpdateSettingSignal.SendToServer(key, value);
 }

--- a/src/client/states/SettingsState.ts
+++ b/src/client/states/SettingsState.ts
@@ -1,0 +1,50 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        SettingsState.ts
+ * @module      SettingsState
+ * @layer       Client
+ * @description Reactive container for player settings.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ */
+
+import Fusion, { Value } from "@rbxts/fusion";
+import { DefaultSettings, PlayerSettings, SETTING_KEYS, SettingKey } from "shared/definitions/Settings";
+import { GetPlayerSettings } from "client/network/CallServer";
+
+export default class SettingsState {
+        private static instance: SettingsState;
+        public Settings: Record<SettingKey, Value<boolean | string>> = {} as never;
+
+        private constructor() {
+                for (const key of SETTING_KEYS) {
+                        this.Settings[key] = Value(DefaultSettings[key]);
+                }
+                this.fetchFromServer();
+        }
+
+        private async fetchFromServer() {
+                const data = await GetPlayerSettings();
+                if (data) {
+                        for (const key of SETTING_KEYS) {
+                                const val = data[key];
+                                this.Settings[key].set(val);
+                        }
+                }
+        }
+
+        public static getInstance(): SettingsState {
+                if (!this.instance) {
+                        this.instance = new SettingsState();
+                }
+                return this.instance;
+        }
+
+        public set(key: SettingKey, value: boolean | string) {
+                this.Settings[key].set(value);
+        }
+}

--- a/src/client/states/index.ts
+++ b/src/client/states/index.ts
@@ -25,3 +25,4 @@
 export * from "./PlayerState";
 export * from "./ScreenState";
 export * from "./ThemeState";
+export { default as SettingsState } from "./SettingsState";

--- a/src/client/ui/molecules/SettingListItem.ts
+++ b/src/client/ui/molecules/SettingListItem.ts
@@ -1,0 +1,95 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        SettingListItem.ts
+ * @module      SettingListItem
+ * @layer       Client/UI/Molecules
+ * @description Theme-aware list item for modifying a player setting.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ */
+
+// -------------- Imports ----------------------------------------------------- //
+import Fusion, { Children, Computed, New, OnChange, OnEvent, Value } from "@rbxts/fusion";
+import { GamePanel, GameButton, GameText } from "client/ui/atoms";
+import { Layout, Padding } from "client/ui/tokens";
+import { SettingKey, SettingsMeta } from "shared/definitions/Settings";
+
+// -------------- Props ------------------------------------------------------- //
+export interface SettingListItemProps extends Fusion.PropertyTable<Frame> {
+        SettingKey: SettingKey;
+        Value: Value<boolean | string>;
+        OnChanged?: (value: boolean | string) => void;
+}
+
+// -------------- Component --------------------------------------------------- //
+export const SettingListItem = (props: SettingListItemProps) => {
+        const meta = SettingsMeta[props.SettingKey];
+        const title = GameText({
+                Name: "SettingName",
+                TextStateValue: Value(meta.displayName),
+                TextSize: 16,
+                AnchorPoint: new Vector2(0, 0),
+                Position: UDim2.fromOffset(0, 0),
+                BackgroundTransparency: 1,
+                TextXAlignment: Enum.TextXAlignment.Left,
+        });
+
+        const description = GameText({
+                Name: "SettingDescription",
+                TextStateValue: Value(meta.description),
+                TextSize: 12,
+                AnchorPoint: new Vector2(0, 0),
+                Position: UDim2.fromOffset(0, 0),
+                BackgroundTransparency: 1,
+                TextXAlignment: Enum.TextXAlignment.Left,
+        });
+
+        let control: Instance;
+        if (meta.controlType === "boolean") {
+                const label = Computed(() => ((props.Value.get() as boolean) ? "On" : "Off"));
+                control = GameButton({
+                        Name: "ToggleButton",
+                        Size: UDim2.fromOffset(60, 24),
+                        OnClick: () => {
+                                const newValue = !(props.Value.get() as boolean);
+                                props.Value.set(newValue);
+                                props.OnChanged?.(newValue);
+                        },
+                        [Children]: {
+                                Label: GameText({
+                                        Name: "ToggleLabel",
+                                        TextStateValue: label as unknown as Value<string>,
+                                        TextSize: 14,
+                                }),
+                        },
+                });
+        } else {
+                control = New("TextBox")({
+                        Name: "TextInput",
+                        Size: UDim2.fromOffset(120, 24),
+                        Text: props.Value as Value<string>,
+                        BackgroundTransparency: 0.3,
+                        [OnChange("Text")]: (txt: string) => {
+                                props.Value.set(txt);
+                                props.OnChanged?.(txt);
+                        },
+                });
+        }
+
+        return GamePanel({
+                Name: props.Name ?? `${props.SettingKey}Item`,
+                Size: props.Size ?? UDim2.fromScale(1, 0),
+                AutomaticSize: Enum.AutomaticSize.Y,
+                Layout: Layout.VerticalSet(2),
+                Padding: Padding(4),
+                Content: {
+                        Title: title,
+                        Description: description,
+                        Control: control,
+                },
+        });
+};

--- a/src/client/ui/molecules/index.ts
+++ b/src/client/ui/molecules/index.ts
@@ -3,3 +3,4 @@ export * from "./FillBar/BarMeter";
 export * from "./CountdownTimer";
 export * from "./GameWindow";
 export * from "./Button";
+export * from "./SettingListItem";

--- a/src/client/ui/screens/SettingsScreen.ts
+++ b/src/client/ui/screens/SettingsScreen.ts
@@ -20,23 +20,31 @@
  *   @rbxts/fusion ^0.4.0
  */
 
-import { GameWindow } from "../molecules";
-import { ScreenKey } from "client/states";
-import { PanelSelector } from "../molecules/Button/PanelSelector";
+import Fusion, { ForPairs } from "@rbxts/fusion";
+import { GameWindow, SettingListItem } from "../molecules";
+import { ScreenKey, SettingsState } from "client/states";
+import { SETTING_KEYS, SettingKey } from "shared/definitions/Settings";
 const Key: ScreenKey = "Settings";
 
 export const SettingsScreen = () => {
-	return GameWindow({
-		Name: `${Key}Screen`,
-		ScreenKey: Key,
-		Content: {
-			SettingsTest: PanelSelector({
-				SelectorKey: "Helmet",
-				Size: new UDim2(1, 0, 0, 50),
-				Position: new UDim2(0, 0, 0, 50),
-				BackgroundColor3: Color3.fromRGB(50, 50, 50),
-				BorderSizePixel: 0,
-			}),
-		},
-	});
+        const state = SettingsState.getInstance();
+        const keys = [...SETTING_KEYS] as SettingKey[];
+        const items = ForPairs(keys, (index, key: SettingKey) =>
+                $tuple(
+                        key,
+                        SettingListItem({
+                                SettingKey: key,
+                                Value: state.Settings[key],
+                                LayoutOrder: index,
+                                OnChanged: (val) => state.set(key, val),
+                        }),
+                ),
+        );
+        return GameWindow({
+                Name: `${Key}Screen`,
+                ScreenKey: Key,
+                Content: {
+                        SettingItems: items,
+                },
+        });
 };

--- a/src/server/network/network.server.ts
+++ b/src/server/network/network.server.ts
@@ -25,10 +25,10 @@ import { HttpService } from "@rbxts/services";
 import { Network } from "shared/network";
 
 /* Custom Services */
-import { DataProfileController, BattleRoomService } from "server/services";
+import { DataProfileController, BattleRoomService, SettingsService } from "server/services";
 
 /* Factories and Types */
-import { AttributeKey, AbilityKey, AbilitiesMeta } from "shared/definitions";
+import { AttributeKey, AbilityKey, AbilitiesMeta, SettingKey } from "shared/definitions";
 import Net from "@rbxts/net";
 import { GetSoulPlayer } from "server/entity/player/SoulPlayer";
 import { playAnimation } from "shared/assets/animations";
@@ -83,7 +83,15 @@ Network.Server.OnEvent("JoinRoom", (player, roomId: string) => {
 });
 
 Network.Server.OnEvent("SetActiveGem", (player, roomId: string, gemId: string) => {
-	BattleRoomService.SetActiveGem(player, roomId, gemId);
+        BattleRoomService.SetActiveGem(player, roomId, gemId);
+});
+
+Network.Server.Get("GetPlayerSettings").SetCallback((player) => {
+        return SettingsService.Get(player);
+});
+
+Network.Server.OnEvent("UpdatePlayerSetting", (player, key: SettingKey, value: boolean | string) => {
+        SettingsService.Set(player, key, value);
 });
 
 print("Network server initialized and listening for events.");

--- a/src/server/services/SettingsService.ts
+++ b/src/server/services/SettingsService.ts
@@ -1,0 +1,46 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        SettingsService.ts
+ * @module      SettingsService
+ * @layer       Server/Services
+ * @classType   Singleton
+ * @description Maintains per-player settings values.
+ */
+
+// -------------- Imports ----------------------------------------------------- //
+import { Players } from "@rbxts/services";
+import { DefaultSettings, PlayerSettings, SettingKey } from "shared/definitions/Settings";
+
+// -------------- Service ----------------------------------------------------- //
+export class SettingsService {
+        private static _instance: SettingsService | undefined;
+        private static _settings = new Map<Player, PlayerSettings>();
+
+        private constructor() {
+                print("SettingsService initialized.");
+        }
+
+        public static Start(): SettingsService {
+                if (!this._instance) {
+                        this._instance = new SettingsService();
+                }
+                return this._instance;
+        }
+
+        public static Get(player: Player): PlayerSettings {
+                const existing = this._settings.get(player);
+                if (existing) return existing;
+                const defaults = { ...DefaultSettings };
+                this._settings.set(player, defaults);
+                return defaults;
+        }
+
+        public static Set(player: Player, key: SettingKey, value: boolean | string) {
+                const settings = this.Get(player);
+                settings[key] = value;
+        }
+}
+
+// Start service on import
+SettingsService.Start();

--- a/src/server/services/index.ts
+++ b/src/server/services/index.ts
@@ -23,3 +23,4 @@
 export * from "./ProfileService";
 export * from "./ManifestationForgeService";
 export * from "./BattleRoomService";
+export * from "./SettingsService";

--- a/src/shared/definitions/Settings.ts
+++ b/src/shared/definitions/Settings.ts
@@ -1,0 +1,54 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        Settings.ts
+ * @module      SettingsDefinitions
+ * @layer       Constants
+ * @description Canonical list of player settings and metadata.
+ *
+ * ╭──────────────────────────────╮
+ * │  Soul Steel · Coding Guide   │
+ * │  Fusion v4 · Strict TS · ECS │
+ * ╰──────────────────────────────╯
+ *
+ * @since        0.2.1
+ * @lastUpdated  2025-07-03 by Codex – Initial creation
+ */
+
+export const SETTING_KEYS = ["musicEnabled", "showFps", "nickname"] as const;
+
+export type SettingKey = (typeof SETTING_KEYS)[number];
+
+export type SettingType = "boolean" | "string";
+
+export interface SettingMeta {
+        displayName: string;
+        description: string;
+        controlType: SettingType;
+}
+
+export const SettingsMeta: Record<SettingKey, SettingMeta> = {
+        musicEnabled: {
+                displayName: "Music",
+                description: "Toggle background music on or off.",
+                controlType: "boolean",
+        },
+        showFps: {
+                displayName: "Show FPS",
+                description: "Display the current frames per second.",
+                controlType: "boolean",
+        },
+        nickname: {
+                displayName: "Nickname",
+                description: "Set a custom player nickname.",
+                controlType: "string",
+        },
+};
+
+export type PlayerSettings = Record<SettingKey, boolean | string>;
+
+export const DefaultSettings: PlayerSettings = {
+        musicEnabled: true,
+        showFps: false,
+        nickname: "",
+};

--- a/src/shared/definitions/index.ts
+++ b/src/shared/definitions/index.ts
@@ -13,3 +13,4 @@ export * from "../data/PlayerData";
 export * from "./Rarity";
 export * from "../data/ResourceData";
 export * from "../storage/Rigs";
+export * from "./Settings";

--- a/src/shared/network/Definitions.ts
+++ b/src/shared/network/Definitions.ts
@@ -9,7 +9,7 @@
 
 /* =============================================== Imports =============================================== */
 import Net from "@rbxts/net";
-import { AbilityKey, AttributeKey } from "shared/definitions";
+import { AbilityKey, AttributeKey, SettingKey, PlayerSettings } from "shared/definitions";
 
 /* =============================================== Network Definitions =============================================== */
 export const Network = Net.Definitions.Create({
@@ -20,7 +20,10 @@ export const Network = Net.Definitions.Create({
 	IncreaseAttribute: Net.Definitions.ClientToServerEvent<[attributeKey: AttributeKey, amount: number]>(),
 	AddGem: Net.Definitions.ClientToServerEvent<[gemid: string]>(),
 	JoinRoom: Net.Definitions.ClientToServerEvent<[roomId: string]>(),
-	SetActiveGem: Net.Definitions.ClientToServerEvent<[roomId: string, gemId: string]>(),
+        SetActiveGem: Net.Definitions.ClientToServerEvent<[roomId: string, gemId: string]>(),
+
+        GetPlayerSettings: Net.Definitions.ServerFunction<(player: Player) => PlayerSettings>(),
+        UpdatePlayerSetting: Net.Definitions.ClientToServerEvent<[key: SettingKey, value: boolean | string]>(),
 
 	// client → server function
 	CreateRoom: Net.Definitions.ServerFunction<() => string>(),


### PR DESCRIPTION
## Summary
- create `Settings` definitions with default values
- add `SettingsService` on the server
- expose `SettingsState` on the client
- implement theme-aware `SettingListItem` molecule
- render settings in `SettingsScreen`
- extend network and call-server helpers
- update barrels and development summary

## Testing
- `npm run build`
- `npm run lint` *(warnings expected)*

------
https://chatgpt.com/codex/tasks/task_e_6863e68626f4832799078df9e7a015ea