### PR TITLE
Improve shared definitions

### DIFF
--- a/src/shared/definitions/Ability.ts
+++ b/src/shared/definitions/Ability.ts
@@ -39,7 +39,7 @@ export interface AbilityMeta {
 	};
 }
 
-export const AbilitiesMeta: Record<AbilityKey, AbilityMeta> = {
+export const AbilitiesMeta = {
 	fireball: {
 		displayName: "Fireball",
 		iconId: GameImages.Ability.Flame_Sythe,
@@ -100,12 +100,12 @@ export const AbilitiesMeta: Record<AbilityKey, AbilityMeta> = {
 			stamina: 5,
 		},
 	},
-} satisfies Record<AbilityKey, AbilityMeta>;
+} as const satisfies Record<AbilityKey, AbilityMeta>;
 
-export const DefaultAbilities: Record<AbilityKey, number> = {
-	fireball: 0,
-	ice_shard: 0,
-	lightning_bolt: 0,
-	earthquake: 0,
-	melee: 0,
-};
+export const DefaultAbilities = ABILITY_KEYS.reduce<Record<AbilityKey, number>>(
+	(obj, key) => {
+		obj[key] = 0;
+		return obj;
+	},
+	{} as Record<AbilityKey, number>,
+);

--- a/src/shared/definitions/Attributes.ts
+++ b/src/shared/definitions/Attributes.ts
@@ -41,23 +41,22 @@ export interface AttributeMeta {
 }
 
 // Attribute Metadata Records
-export const AttributesMeta: Record<AttributeKey, AttributeMeta> = {
+export const AttributesMeta = {
 	str: { displayName: "Strength", iconId: "rbxassetid://127745571044516", min: 1, max: 999 },
 	agi: { displayName: "Agility", iconId: "rbxassetid://73893872719367", min: 1, max: 999 },
 	vit: { displayName: "Vitality", iconId: "rbxassetid://121291227474039", min: 1, max: 999 },
 	int: { displayName: "Intellect", iconId: "rbxassetid://107600003376684", min: 1, max: 999 },
 	lck: { displayName: "Luck", iconId: "rbxassetid://114767496083209", min: 1, max: 999 },
-} satisfies Record<AttributeKey, AttributeMeta>;
+} as const satisfies Record<AttributeKey, AttributeMeta>;
 
 // Default attributes with initial values
 export const DefaultAttributes: AttributesDTO = {
-	str: 10,
-	agi: 10,
-	vit: 10,
-	int: 10,
-	lck: 10,
-	AvailablePoints: 5, // Starting with 5 points to distribute
-	SpentPoints: 0, // No points spent initially
+	AvailablePoints: 5,
+	SpentPoints: 0,
+	...ATTR_KEYS.reduce<AttributesMap>((obj, key) => {
+		obj[key] = 10;
+		return obj;
+	}, {} as AttributesMap),
 };
 
 // Helper Functions

--- a/src/shared/definitions/Currency.ts
+++ b/src/shared/definitions/Currency.ts
@@ -1,3 +1,12 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        Currency.ts
+ * @module      CurrencyDefinitions
+ * @layer       Shared/Data
+ * @description Canonical list of in-game currencies and their metadata.
+ */
+
 export const CURRENCY_KEY = ["GOLD", "SILVER", "BRONZE"] as const;
 export type CurrencyKey = (typeof CURRENCY_KEY)[number];
 export interface CurrencyMeta {
@@ -5,16 +14,15 @@ export interface CurrencyMeta {
 	iconId: string;
 }
 
-export const CurrencyMetaMap: Record<CurrencyKey, CurrencyMeta> = {
+export const CurrencyMetaMap = {
 	GOLD: { displayName: "Gold", iconId: "rbxassetid://1234567890" },
 	SILVER: { displayName: "Silver", iconId: "rbxassetid://1234567891" },
 	BRONZE: { displayName: "Bronze", iconId: "rbxassetid://1234567892" },
-} satisfies Record<CurrencyKey, CurrencyMeta>;
+} as const satisfies Record<CurrencyKey, CurrencyMeta>;
 
 export type CurrencyMap = Record<CurrencyKey, number>;
 
-export const DefaultCurrency: CurrencyMap = {
-	GOLD: 0,
-	SILVER: 0,
-	BRONZE: 0,
-};
+export const DefaultCurrency = CURRENCY_KEY.reduce<CurrencyMap>((obj, key) => {
+	obj[key] = 0;
+	return obj;
+}, {} as CurrencyMap);

--- a/src/shared/definitions/Equipment.ts
+++ b/src/shared/definitions/Equipment.ts
@@ -1,3 +1,12 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        Equipment.ts
+ * @module      EquipmentDefinitions
+ * @layer       Shared/Data
+ * @description Enumerates equipment slots and their metadata.
+ */
+
 import { GameImages } from "shared/assets";
 
 export const EQUIPMENT_SLOT_KEYS = ["Helmet", "Chest", "Back", "Necklace", "Ring"] as const;
@@ -14,10 +23,10 @@ export interface EquipmentSlotMeta {
 }
 
 // Equipment Slot Metadata Records
-export const EquipmentSlotMeta: Record<EquipmentSlotKey, EquipmentSlotMeta> = {
+export const EquipmentSlotMeta = {
 	Helmet: { displayName: "Helmet", iconId: GameImages.SlotImage.Helmet },
 	Chest: { displayName: "Chest", iconId: GameImages.SlotImage.Armor },
 	Back: { displayName: "Back", iconId: GameImages.SlotImage.Accessory },
 	Necklace: { displayName: "Necklace", iconId: GameImages.SlotImage.Accessory },
 	Ring: { displayName: "Ring", iconId: GameImages.SlotImage.Accessory },
-} satisfies Record<EquipmentSlotKey, EquipmentSlotMeta>;
+} as const satisfies Record<EquipmentSlotKey, EquipmentSlotMeta>;

--- a/src/shared/definitions/Loot.ts
+++ b/src/shared/definitions/Loot.ts
@@ -46,7 +46,7 @@ export interface LootTableMeta {
 	guaranteed?: readonly Omit<LootEntry, "weight">[];
 }
 
-export const LootTableMetaMap: Readonly<Record<LootTableKey, LootTableMeta>> = {
+export const LootTableMetaMap = {
 	/*───────────────────────────────────────────────────────────────
     Goblin trash mobs – nothing fancy
   ───────────────────────────────────────────────────────────────*/
@@ -115,4 +115,4 @@ export const LootTableMetaMap: Readonly<Record<LootTableKey, LootTableMeta>> = {
 			{ drop: "LARGE_HEALTH_POTION", quantity: 2, weight: 25 },
 		],
 	},
-} as const;
+} as const satisfies Record<LootTableKey, LootTableMeta>;

--- a/src/shared/definitions/NPC.ts
+++ b/src/shared/definitions/NPC.ts
@@ -7,7 +7,6 @@
 
 import { AbilityKey } from "./Ability";
 import { LootTableKey } from "./Loot";
-import { AnimationKey } from "../assets";
 
 export const NPC_KEYS = ["GOBLIN_SCOUT", "GOBLIN_ARCHER", "SKELETON_WARRIOR", "CRYSTAL_GOLEM"] as const;
 
@@ -30,7 +29,6 @@ export interface NPCMeta {
 	abilities: AbilityKey[];
 	/** Loot-table key rolled on death */
 	lootTable: LootTableKey;
-	/** Animation set reference for the AnimationController binder */
 
 	/** Optional behaviour flags or AI profiles */
 	aiProfile?: "melee" | "ranged" | "caster" | "tank";

--- a/src/shared/definitions/Rarity.ts
+++ b/src/shared/definitions/Rarity.ts
@@ -24,7 +24,7 @@ export interface RarityMeta {
 }
 
 // Rarity Metadata Records
-export const RarityMeta: Record<RarityKey, RarityMeta> = {
+export const RarityMeta = {
 	Common: {
 		label: "Common",
 		color: Color3.fromRGB(200, 200, 200),
@@ -50,4 +50,4 @@ export const RarityMeta: Record<RarityKey, RarityMeta> = {
 		color: Color3.fromRGB(255, 215, 0),
 		BorderImage: GameImages.Borders.GothicMetal, // Gold border for legendary
 	},
-} satisfies Record<RarityKey, RarityMeta>;
+} as const satisfies Record<RarityKey, RarityMeta>;

--- a/src/shared/definitions/Settings.ts
+++ b/src/shared/definitions/Settings.ts
@@ -27,7 +27,7 @@ export interface SettingMeta {
 	controlType: SettingType;
 }
 
-export const SettingsMeta: Record<SettingKey, SettingMeta> = {
+export const SettingsMeta = {
 	musicEnabled: {
 		displayName: "Music",
 		description: "Toggle background music on or off.",
@@ -43,12 +43,12 @@ export const SettingsMeta: Record<SettingKey, SettingMeta> = {
 		description: "Set a custom player nickname.",
 		controlType: "string",
 	},
-};
+} as const satisfies Record<SettingKey, SettingMeta>;
 
 export type PlayerSettings = Record<SettingKey, boolean | string>;
 
-export const DefaultSettings: PlayerSettings = {
+export const DefaultSettings = {
 	musicEnabled: true,
 	showFps: false,
 	nickname: "",
-};
+} as const satisfies PlayerSettings;


### PR DESCRIPTION
## Summary
- refactor definitions to use `satisfies` and computed defaults
- add missing TSDoc headers
- remove unused imports

## Testing
- `npm run lint`
- `npm run lint:fix`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68651079a9cc8327a432853677d188db