### PR TITLE
Redesign server NPC system

### DIFF
--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -45,9 +45,9 @@ The table below lists core modules grouped by network layer and their current st
 |Server|`server/services/BattleRoomService.ts`|Usable|Matchmaking and teleport skeleton|
 |Server|`server/services/SettingsService.ts`|Usable|Stores player settings|
 |Server|`server/entity/Manifestation.ts`|Stub|Placeholder creation logic|
-|Server|`server/entity/npc/NPC.ts`|Usable|Basic NPC class|
+|Server|`server/services/NPCService.ts`|Usable|Spawns NPCs from definitions|
+|Server|`server/entity/npc/NPC.ts`|Usable|NPC instance with random names|
 |Server|`server/entity/player/SoulPlayer.ts`|Usable|Player data container|
 |Server|`server/entity/entityResource/EntityResource.ts`|Usable|Drops collectible resource|
-|Server|`server/factories/NPCFactory.ts`|Stub|Creates NPC instances|
 
 Keep this summary updated whenever modules are added or changed.

--- a/src/server/entity/npc/NPC.ts
+++ b/src/server/entity/npc/NPC.ts
@@ -4,7 +4,7 @@
  * @file        NPC.ts
  * @module      NPC
  * @layer       Server/Entity
- * @description Basic non-player character with attributes.
+ * @description Runtime representation of an NPC spawned from NPCMetaMap.
  *
  * ╭───────────────────────────────╮
  * │  Soul Steel · Coding Guide    │
@@ -14,22 +14,55 @@
  * @author       Trembus
  * @license      MIT
  * @since        0.2.0
- * @lastUpdated  2025-06-25 by Trembus – Initial creation
+ * @lastUpdated  2025-07-02 by Codex – Redesigned to use new NPC definitions
  */
 
-import { createAttributes, NPCKey, NPCMeta, NPCMetaMap } from "shared";
-import { ReplicatedStorage } from "@rbxts/services";
+import {
+        NPCKey,
+        NPCMeta,
+        NPCMetaMap,
+        FIRST_NAMES,
+        LAST_NAMES,
+        MONIKERS,
+} from "shared/definitions/NPC";
+import { LoadAbilityAnimations } from "../helpers";
+
 export class NPC {
-	// NPC properties
-	public readonly meta: NPCMeta;
-	public readonly name: string;
-	public readonly model: Model;
-	constructor(key: NPCKey, cFrame: CFrame = new CFrame()) {
-		this.meta = NPCMetaMap[key];
-		this.name = this.meta.displayName;
-		this.model = this.meta.modelTemplate.Clone();
-		this.model.PivotTo(cFrame);
-		this.model.Parent = game.Workspace;
-		warn(`NPC created: ${this.name} at`, cFrame);
-	}
+        public readonly key: NPCKey;
+        public readonly meta: NPCMeta;
+        public readonly model: Model;
+        public readonly humanoid?: Humanoid;
+        public readonly stats: Readonly<typeof NPCMetaMap[NPCKey] extends infer M ? M extends { baseStats: infer B } ? B : never : never>;
+        public readonly name: string;
+
+        constructor(key: NPCKey, cFrame: CFrame = new CFrame()) {
+                this.key = key;
+                this.meta = NPCMetaMap[key];
+                this.model = this.meta.modelTemplate.Clone();
+                this.humanoid = this.model.FindFirstChildOfClass("Humanoid") as Humanoid | undefined;
+                this.stats = { ...this.meta.baseStats };
+                this.name = NPC.generateName(key);
+
+                this.model.Name = this.name;
+                this.model.PivotTo(cFrame);
+                this.model.Parent = game.Workspace;
+
+                LoadAbilityAnimations(this.model, this.meta.abilities);
+                print(`NPC spawned: ${this.name} (${key})`);
+        }
+
+        public Destroy() {
+                this.model.Destroy();
+        }
+
+        private static randomOf<T>(array: readonly T[]): T {
+                return array[math.random(0, array.size() - 1)];
+        }
+
+        public static generateName(key: NPCKey): string {
+                const first = this.randomOf(FIRST_NAMES);
+                const last = this.randomOf(LAST_NAMES);
+                const moniker = this.randomOf(MONIKERS[key]);
+                return `${first} ${last} ${moniker}`;
+        }
 }

--- a/src/server/network/network.server.ts
+++ b/src/server/network/network.server.ts
@@ -25,12 +25,11 @@ import { HttpService } from "@rbxts/services";
 import { Network, TestNetwork } from "shared/network";
 
 /* Custom Services */
-import { BattleRoomService, SettingsService } from "server/services";
+import { BattleRoomService, SettingsService, NPCService } from "server/services";
 
 /* Factories and Types */
 import { AttributeKey, AbilityKey, SettingKey, NPCKey } from "shared/definitions";
 import SoulPlayer from "server/entity/player/SoulPlayer";
-import { NPC } from "server/entity";
 
 // INCREASE ATTRIBUTE
 Network.Server.OnEvent("IncreaseAttribute", (player, attributeKey: AttributeKey, amount: number) => {
@@ -79,16 +78,12 @@ Network.Server.OnEvent("UpdatePlayerSetting", (player, key: SettingKey, value: b
 
 // Admin Actions -----------------------------------------------------
 TestNetwork.Server.OnEvent("SPAWN_NPC", (player, npcKey: NPCKey) => {
-	print(`Spawning NPC: ${npcKey}`);
-	const playerCharacter = player.Character || player.CharacterAdded.Wait()[0];
-	if (playerCharacter === undefined) {
-		warn(`Player ${player.Name} has no character to spawn NPC into.`);
-		return;
-	}
-	const playerCFrame = playerCharacter.GetPivot();
-	const inFrontOffset = new Vector3(0, 0, -5); // Adjust as needed
-	const spawnPosition = playerCFrame.mul(new CFrame(0, 0, -5)); // Spawn in front of player
-	const spawnPosition2 = new CFrame(playerCFrame.Position.add(inFrontOffset));
-
-	const npc = new NPC(npcKey, spawnPosition);
+        const playerCharacter = player.Character || player.CharacterAdded.Wait()[0];
+        if (playerCharacter === undefined) {
+                warn(`Player ${player.Name} has no character to spawn NPC into.`);
+                return;
+        }
+        const playerCFrame = playerCharacter.GetPivot();
+        const spawnCFrame = playerCFrame.mul(new CFrame(0, 0, -5));
+        NPCService.Spawn(npcKey, spawnCFrame);
 });

--- a/src/server/services/NPCService.ts
+++ b/src/server/services/NPCService.ts
@@ -1,0 +1,53 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        NPCService.ts
+ * @module      NPCService
+ * @layer       Server/Services
+ * @classType   Singleton
+ * @description Spawns and tracks NPC instances using NPC definitions.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Trembus
+ * @license      MIT
+ * @since        0.2.0
+ * @lastUpdated  2025-07-02 by Codex – Initial creation
+ */
+
+import { NPCKey } from "shared/definitions/NPC";
+import { NPC } from "server/entity";
+
+export class NPCService {
+        private static _instance: NPCService | undefined;
+        private readonly _npcs = new Set<NPC>();
+
+        private constructor() {
+                print("NPCService initialized.");
+        }
+
+        public static Start(): NPCService {
+                if (!this._instance) {
+                        this._instance = new NPCService();
+                }
+                return this._instance;
+        }
+
+        public static Spawn(key: NPCKey, cFrame: CFrame): NPC {
+                const svc = this.Start();
+                const npc = new NPC(key, cFrame);
+                svc._npcs.add(npc);
+                return npc;
+        }
+
+        public static Remove(npc: NPC) {
+                const svc = this.Start();
+                if (svc._npcs.has(npc)) {
+                        svc._npcs.delete(npc);
+                        npc.Destroy();
+                }
+        }
+}

--- a/src/server/services/index.ts
+++ b/src/server/services/index.ts
@@ -24,3 +24,4 @@ export * from "./DataService";
 export * from "./ManifestationForgeService";
 export * from "./BattleRoomService";
 export * from "./SettingsService";
+export * from "./NPCService";


### PR DESCRIPTION
## Summary
- create `NPCService` to spawn and track NPC instances
- redesign `NPC` to pull data from new `NPCMetaMap` and generate random names
- spawn NPCs via NPCService in `network.server.ts`
- update service barrel export
- refresh development summary

## Testing
- `npm run build`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68651b329ce08327b2f0982435efebcb