### PR TITLE
Add ability & status effect services

### DIFF
--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -46,6 +46,8 @@ The table below lists core modules grouped by network layer and their current st
 |Server|`server/services/SettingsService.ts`|Usable|Stores player settings|
 |Server|`server/entity/Manifestation.ts`|Stub|Placeholder creation logic|
 |Server|`server/services/NPCService.ts`|Usable|Spawns NPCs from definitions|
+|Server|`server/services/AbilityService.ts`|Under Construction|Handles ability activation and cooldowns|
+|Server|`server/services/StatusEffectService.ts`|Under Construction|Applies periodic status effects|
 |Server|`server/entity/npc/NPC.ts`|Usable|NPC instance with random names|
 |Server|`server/entity/player/SoulPlayer.ts`|Usable|Player data container|
 |Server|`server/entity/entityResource/EntityResource.ts`|Usable|Drops collectible resource|

--- a/src/server/network/listener.server.ts
+++ b/src/server/network/listener.server.ts
@@ -25,7 +25,12 @@ import { HttpService } from "@rbxts/services";
 import { ClientDispatch, Network, TestNetwork } from "shared/network";
 
 /* Custom Services */
-import { BattleRoomService, SettingsService, NPCService } from "server/services";
+import {
+       BattleRoomService,
+       SettingsService,
+       NPCService,
+       AbilityService,
+} from "server/services";
 
 /* Factories and Types */
 import { AttributeKey, AbilityKey, SettingKey, NPCKey, ProfileDataKey } from "shared/definitions";
@@ -45,17 +50,11 @@ Network.Server.OnEvent("IncreaseAttribute", (player, attributeKey: AttributeKey,
 
 // Abilities -----------------------------------------------------
 Network.Server.OnEvent("ActivateAbility", (player: Player, abilityKey: AbilityKey) => {
-	const soulPlayer = SoulPlayer.GetSoulPlayer(player);
-	soulPlayer?.ActivateAbility(abilityKey);
+       AbilityService.Activate(player, abilityKey);
 });
 
 Network.Server.Get("GetPlayerAbilities").SetCallback((player) => {
-	const soulPlayer = SoulPlayer.GetSoulPlayer(player);
-	if (soulPlayer === undefined) {
-		warn(`SoulPlayer not found for ${player.Name}`);
-		return undefined;
-	}
-	return soulPlayer.GetAbilities();
+       return AbilityService.GetAbilities(player);
 });
 
 // MATCHMAKING -----------------------------------------------------

--- a/src/server/services/AbilityService.ts
+++ b/src/server/services/AbilityService.ts
@@ -1,0 +1,81 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        AbilityService.ts
+ * @module      AbilityService
+ * @layer       Server/Services
+ * @classType   Singleton
+ * @description Manages player abilities and activation cooldowns.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Codex
+ * @license      MIT
+ * @since        0.2.0
+ * @lastUpdated  2025-07-03 by Codex – Initial creation
+ */
+
+/* =============================================== Imports =============================================== */
+import { AbilitiesMeta, AbilityKey, loadAnimation, playAnimation } from "shared";
+import { DataProfileController } from "./DataService";
+import { CooldownTimer } from "shared/classes/CooldownTimer";
+
+/* =============================================== Service =============================================== */
+export class AbilityService {
+        private static _instance: AbilityService | undefined;
+        private readonly _cooldowns = new Map<Player, Map<AbilityKey, CooldownTimer>>();
+
+        private constructor() {
+                print("AbilityService initialized.");
+        }
+
+        public static Start(): AbilityService {
+                if (!this._instance) {
+                        this._instance = new AbilityService();
+                }
+                return this._instance;
+        }
+
+        /* ------------------------------- Ability Retrieval ------------------------------- */
+        public static GetAbilities(player: Player): AbilityKey[] | undefined {
+                const profile = DataProfileController.GetProfile(player);
+                return profile?.Data.Abilities;
+        }
+
+        /* ------------------------------- Ability Activation ------------------------------ */
+        public static Activate(player: Player, abilityKey: AbilityKey) {
+                const svc = this.Start();
+                const abilities = this.GetAbilities(player);
+                if (!abilities || !abilities.includes(abilityKey)) {
+                        warn(`Player ${player.Name} does not have ability ${abilityKey}.`);
+                        return;
+                }
+
+                let playerCooldowns = svc._cooldowns.get(player);
+                if (!playerCooldowns) {
+                        playerCooldowns = new Map<AbilityKey, CooldownTimer>();
+                        svc._cooldowns.set(player, playerCooldowns);
+                }
+
+                const existing = playerCooldowns.get(abilityKey);
+                if (existing && !existing.isReady()) {
+                        warn(`Ability ${abilityKey} on cooldown for player ${player.Name}.`);
+                        return;
+                }
+
+                const cooldown = AbilitiesMeta[abilityKey]?.cooldown ?? 0;
+                const timer = new CooldownTimer(cooldown);
+                playerCooldowns.set(abilityKey, timer);
+                timer.start();
+
+                const character = player.Character || player.CharacterAdded.Wait()[0];
+                loadAnimation(character, AbilitiesMeta[abilityKey].animationKey);
+                playAnimation(character, AbilitiesMeta[abilityKey].animationKey);
+        }
+}
+
+// Auto-start on import
+AbilityService.Start();

--- a/src/server/services/StatusEffectService.ts
+++ b/src/server/services/StatusEffectService.ts
@@ -1,0 +1,79 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        StatusEffectService.ts
+ * @module      StatusEffectService
+ * @layer       Server/Services
+ * @classType   Singleton
+ * @description Applies and tracks status effects on players.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Codex
+ * @license      MIT
+ * @since        0.2.0
+ * @lastUpdated  2025-07-03 by Codex – Initial creation
+ */
+
+/* =============================================== Imports =============================================== */
+import { EffectMeta, EffectTypeKey } from "shared/definitions/Effects";
+
+/* =============================================== Service =============================================== */
+export class StatusEffectService {
+        private static _instance: StatusEffectService | undefined;
+        private readonly _effects = new Map<Player, Map<EffectTypeKey, thread>>();
+
+        private constructor() {
+                print("StatusEffectService initialized.");
+        }
+
+        public static Start(): StatusEffectService {
+                if (!this._instance) {
+                        this._instance = new StatusEffectService();
+                }
+                return this._instance;
+        }
+
+        /* ------------------------------- Public API ------------------------------- */
+        public static AddEffect(player: Player, effectKey: EffectTypeKey) {
+                const meta = EffectMeta[effectKey];
+                const svc = this.Start();
+                let map = svc._effects.get(player);
+                if (!map) {
+                        map = new Map<EffectTypeKey, thread>();
+                        svc._effects.set(player, map);
+                }
+                if (map.has(effectKey)) return;
+
+                const runner = task.spawn(() => {
+                        while (map!.has(effectKey)) {
+                                print(`Applying ${effectKey} to ${player.Name}: ${meta.amount}`);
+                                task.wait(meta.tickRate);
+                        }
+                });
+                map.set(effectKey, runner);
+        }
+
+        public static RemoveEffect(player: Player, effectKey: EffectTypeKey) {
+                const svc = this.Start();
+                const map = svc._effects.get(player);
+                if (!map) return;
+                const th = map.get(effectKey);
+                if (th) task.cancel(th);
+                map.delete(effectKey);
+        }
+
+        public static ClearEffects(player: Player) {
+                const svc = this.Start();
+                const map = svc._effects.get(player);
+                if (!map) return;
+                map.forEach((th) => task.cancel(th));
+                svc._effects.delete(player);
+        }
+}
+
+// Auto-start on import
+StatusEffectService.Start();

--- a/src/server/services/index.ts
+++ b/src/server/services/index.ts
@@ -25,3 +25,5 @@ export * from "./ManifestationForgeService";
 export * from "./BattleRoomService";
 export * from "./SettingsService";
 export * from "./NPCService";
+export * from "./AbilityService";
+export * from "./StatusEffectService";


### PR DESCRIPTION
## Summary
- implement `AbilityService` for player ability activation
- implement `StatusEffectService` for managing periodic effects
- export new services and hook into network listener
- document new modules in development summary

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6866998ed67c832794d4465d51afabb4