### PR TITLE
Add ResourcesService for tracking player resources

### DIFF
--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -48,6 +48,7 @@ The table below lists core modules grouped by network layer and their current st
 |Server|`server/services/NPCService.ts`|Usable|Spawns NPCs from definitions|
 |Server|`server/services/AbilityService.ts`|Under Construction|Handles ability activation and cooldowns|
 |Server|`server/services/StatusEffectService.ts`|Under Construction|Applies periodic status effects|
+|Server|`server/services/ResourcesService.ts`|Under Construction|Tracks player resource values|
 |Server|`server/entity/npc/NPC.ts`|Usable|NPC instance with random names|
 |Server|`server/entity/player/SoulPlayer.ts`|Usable|Player data container|
 |Server|`server/entity/entityResource/EntityResource.ts`|Usable|Drops collectible resource|

--- a/src/server/services/ResourcesService.ts
+++ b/src/server/services/ResourcesService.ts
@@ -1,0 +1,108 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        ResourcesService.ts
+ * @module      ResourcesService
+ * @layer       Server/Services
+ * @classType   Singleton
+ * @description Tracks player resources like Health, Mana and Stamina.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Codex
+ * @license      MIT
+ * @since        0.2.0
+ * @lastUpdated  2025-07-03 by Codex – Initial creation
+ */
+
+/* =============================================== Imports ===================== */
+import { Players } from "@rbxts/services";
+import { ResourceKey, ResourceDTO, RESOURCE_KEYS, DEFAULT_RESOURCES } from "shared/definitions/Resources";
+import { DefaultAttributes, AttributesDTO } from "shared/definitions/ProfileDefinitions/Attributes";
+import { DataProfileController } from "./DataService";
+import { ResourceFormula } from "shared/calculations/ResourceCalculator";
+import { ServerDispatchEvents } from "shared/network/Definitions";
+
+/* =============================================== Service ===================== */
+export class ResourcesService {
+    private static _instance: ResourcesService | undefined;
+    private readonly _map = new Map<Player, Record<ResourceKey, ResourceDTO>>();
+
+    private constructor() {
+        print("ResourcesService initialized.");
+        this._setupConnections();
+    }
+
+    public static Start(): ResourcesService {
+        if (!this._instance) {
+            this._instance = new ResourcesService();
+        }
+        return this._instance;
+    }
+
+    /* ------------------------------- Public API ------------------------------- */
+    public static GetResources(player: Player): Record<ResourceKey, ResourceDTO> | undefined {
+        return this.Start()._map.get(player);
+    }
+
+    public static ModifyResource(player: Player, key: ResourceKey, delta: number) {
+        const svc = this.Start();
+        const resources = svc._map.get(player);
+        if (!resources) return;
+        const data = resources[key];
+        if (!data) return;
+        const newCurrent = math.clamp(data.current + delta, 0, data.max);
+        if (newCurrent === data.current) return;
+        data.current = newCurrent;
+        ServerDispatchEvents.Server.Get("ResourceUpdated").SendToPlayer(player, key, data.current, data.max);
+    }
+
+    public static Recalculate(player: Player) {
+        const svc = this.Start();
+        const profile = DataProfileController.GetProfile(player);
+        const attrs: AttributesDTO = profile?.Data.Attributes ?? DefaultAttributes;
+        const level = (profile as unknown as { Data: { Level?: number } })?.Data?.Level ?? 1;
+
+        let resources = svc._map.get(player);
+        if (!resources) {
+            resources = { ...DEFAULT_RESOURCES };
+            svc._map.set(player, resources);
+        }
+
+        (RESOURCE_KEYS as ReadonlyArray<ResourceKey>).forEach((key) => {
+            const max = ResourceFormula[key](attrs, level);
+            const data = resources![key];
+            const changed = data.max !== max;
+            data.max = max;
+            if (data.current > max) {
+                data.current = max;
+            }
+            if (changed) {
+                ServerDispatchEvents.Server.Get("ResourceUpdated").SendToPlayer(player, key, data.current, data.max);
+            }
+        });
+    }
+
+    /* ------------------------------- Internal -------------------------------- */
+    private _setupConnections() {
+        Players.PlayerAdded.Connect((p) => this._onJoin(p));
+        Players.PlayerRemoving.Connect((p) => this._onLeave(p));
+        Players.GetPlayers().forEach((p) => this._onJoin(p));
+    }
+
+    private _onJoin(player: Player) {
+        task.defer(() => {
+            this.Recalculate(player);
+        });
+    }
+
+    private _onLeave(player: Player) {
+        this._map.delete(player);
+    }
+}
+
+// Auto-start on import
+ResourcesService.Start();

--- a/src/server/services/index.ts
+++ b/src/server/services/index.ts
@@ -27,3 +27,4 @@ export * from "./SettingsService";
 export * from "./NPCService";
 export * from "./AbilityService";
 export * from "./StatusEffectService";
+export * from "./ResourcesService";


### PR DESCRIPTION
## Summary
- implement `ResourcesService` singleton for server
- recalc player Health/Mana/Stamina on join
- expose service via barrel export
- document service in dev summary

## Testing
- `npm run lint` *(fails: 161 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6866b96fc8248327965bee097fc03427