### PR TITLE
Implement resource update listener

### DIFF
--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -31,6 +31,8 @@ The table below lists core modules grouped by network layer and their current st
 |Client|`client/ui/molecules/TitleBar.ts`|Usable|Window title bar component|
 |Client|`client/ui/molecules/SettingListItem.ts`|Usable|Displays and edits a single setting|
 |Client|`client/states/SettingsState.ts`|Usable|Reactive settings container|
+|Client|`client/network/CallServer.ts`|Usable|Client RPC helpers|
+|Client|`client/network/listener.client.ts`|Usable|Receives server events|
 |Client|`client/ui/screens`|Under Construction|Gem forge, character, inventory, shop, settings, teleport and HUD screens|
 |Client|`client/ui/screens/DragDropScreen.ts`|Usable|Drag and drop demo|
 |Client|`client/ui/screens/CharacterScreen.ts`|Stub|Character info window|

--- a/src/client/network/listener.client.ts
+++ b/src/client/network/listener.client.ts
@@ -1,24 +1,20 @@
 import PlayerState from "client/states/PlayerState";
-import { Network } from "shared";
+import { Network, ServerDispatchEvents } from "shared";
 
 /* ------------------------------------ Network Listener ------------------------------------ */
 
 // PLAYER RESOURCE: Listen for resource updates from the server
-// Network.Client.OnEvent("ResourceUpdate", (key, current, max) => {
-// 	const playerState = PlayerState.getInstance();
-// 	if (playerState) {
-// 		const resource = playerState.PlayerResources[key];
-// 		if (resource) {
-// 			resource.Current.set(current);
-// 			resource.Max.set(max);
-// 			print(`Resource ${key} updated: Current=${current}, Max=${max}`);
-// 		} else {
-// 			warn(`Resource ${key} not found in PlayerState.`);
-// 		}
-// 	} else {
-// 		warn("PlayerState instance not found.");
-// 	}
-// });
+ServerDispatchEvents.Client.OnEvent("ResourceUpdated", (key, current, max) => {
+    const playerState = PlayerState.getInstance();
+    const resource = playerState.PlayerResources[key];
+    if (resource) {
+        resource.Current.set(current);
+        resource.Max.set(max);
+        print(`Resource ${key} updated: Current=${current}, Max=${max}`);
+    } else {
+        warn(`Resource ${key} not found in PlayerState.`);
+    }
+});
 
 // Profile Changed: Listen for profile changes from the server
 Network.Client.OnEvent("ProfileChanged", (data) => {


### PR DESCRIPTION
## Summary
- hook up `ResourceUpdated` client event
- update `PlayerState` resources when the server sends an update
- document `client/network` modules in development summary

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6866f94d0f548327a819762bb07e7255