### PR TITLE
Refactor PlayerState for profile data

### DIFF
--- a/src/client/network/CallServer.ts
+++ b/src/client/network/CallServer.ts
@@ -1,5 +1,5 @@
 import { Players } from "@rbxts/services";
-import { AbilityKey, Network, SettingKey, PlayerSettings } from "shared";
+import { AbilityKey, Network, SettingKey, PlayerSettings, ProfileDataKey, ProfileDataMap, ClientDispatch } from "shared";
 
 /* Event Signals */
 const ActivateAbilitySignal = Network.Client.Get("ActivateAbility");
@@ -8,6 +8,7 @@ const UpdateSettingSignal = Network.Client.Get("UpdatePlayerSetting");
 /* Function Signals */
 const GetPlayerAbilitiesSignal = Network.Client.Get("GetPlayerAbilities");
 const GetPlayerSettingsSignal = Network.Client.Get("GetPlayerSettings");
+const GetProfileDataSignal = ClientDispatch.Client.Get("GetData");
 
 export async function GetPlayerAbilities(): Promise<AbilityKey[] | undefined> {
 	return await GetPlayerAbilitiesSignal.CallServerAsync(Players.LocalPlayer);
@@ -18,9 +19,15 @@ export function ActivateAbility(abilityKey: AbilityKey): void {
 }
 
 export async function GetPlayerSettings(): Promise<PlayerSettings> {
-	return await GetPlayerSettingsSignal.CallServerAsync(Players.LocalPlayer);
+        return await GetPlayerSettingsSignal.CallServerAsync(Players.LocalPlayer);
 }
 
 export function UpdatePlayerSetting(key: SettingKey, value: boolean | string): void {
-	UpdateSettingSignal.SendToServer(key, value);
+        UpdateSettingSignal.SendToServer(key, value);
+}
+
+export async function GetProfileData<K extends ProfileDataKey>(
+       key: K,
+): Promise<ProfileDataMap[K] | undefined> {
+       return await GetProfileDataSignal.CallServerAsync(key);
 }

--- a/src/client/network/listener.client.ts
+++ b/src/client/network/listener.client.ts
@@ -5,8 +5,8 @@ import { Network, ServerDispatchEvents } from "shared";
 
 // PLAYER RESOURCE: Listen for resource updates from the server
 ServerDispatchEvents.Client.OnEvent("ResourceUpdated", (key, current, max) => {
-	const playerState = PlayerState.getInstance();
-	const resource = playerState.PlayerResources[key];
+       const playerState = PlayerState.getInstance();
+       const resource = playerState.Resources[key];
 	if (resource) {
 		resource.Current.set(current);
 		resource.Max.set(max);

--- a/src/client/ui/organisms/ButtonBars/AbilityBar.ts
+++ b/src/client/ui/organisms/ButtonBars/AbilityBar.ts
@@ -26,7 +26,6 @@
  */
 
 import { Computed, Value } from "@rbxts/fusion";
-import { GetPlayerAbilities } from "client/network/CallServer";
 import PlayerState from "client/states/PlayerState";
 import { GamePanel } from "client/ui/atoms";
 import { AbilityButton } from "client/ui/molecules";
@@ -57,6 +56,6 @@ export function AbilityBar(props: AbilityBarProps) {
 	});
 }
 export const SoulPlayerAbilityBar = (player: Player) => {
-	const abilitiesState = PlayerState.getInstance().PlayerAbilities;
-	return AbilityBar({ abilities: abilitiesState });
+       const abilitiesState = PlayerState.getInstance().Abilities;
+       return AbilityBar({ abilities: abilitiesState });
 };

--- a/src/client/ui/organisms/ResourceBar.ts
+++ b/src/client/ui/organisms/ResourceBar.ts
@@ -30,9 +30,9 @@ import { Computed } from "@rbxts/fusion";
 
 // -------------- Local helpers --------------------------------------------- //
 export function ResourceBar(resourceKey: ResourceKey) {
-	const playerState = PlayerState.getInstance();
+       const playerState = PlayerState.getInstance();
 
-	const state = playerState.PlayerResources[resourceKey];
+       const state = playerState.Resources[resourceKey];
 	const meta = ResourceMeta[resourceKey];
 	const resourceBarContainer = GamePanel({
 		Name: `${resourceKey}BarContainer`,
@@ -40,7 +40,7 @@ export function ResourceBar(resourceKey: ResourceKey) {
 		LayoutOrder: meta.layoutOrder,
 		Content: {
 			FillBar: BarMeter({
-				ProgressState: Computed(() => state.Current.get() / state.Max.get()),
+                               ProgressState: state.Percent,
 				MaxValue: state.Max,
 				Gradient: meta.gradient,
 				Size: UDim2.fromScale(1, 1),


### PR DESCRIPTION
## Summary
- refactor PlayerState to store attributes, currency and resources as Fusion values
- compute resource fill percentage with Computed
- fetch profile data via new GetProfileData client call
- update networking listener and UI components for new PlayerState API

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6867aecc691883279e030b52a1b9a258