### PR TITLE
Implement AttributesService and docs cleanup

### DIFF
--- a/NEXTSTEPS_TODO.md
+++ b/NEXTSTEPS_TODO.md
@@ -1,0 +1,10 @@
+# Next Steps
+
+This document captures potential improvements and follow-up tasks for the current services-based architecture.
+
+- Flesh out **AttributesService** with proper validation (level scaling, spendable point limits).
+- Expose server-side attribute updates to the client through a new network event.
+- Expand **ResourcesService** regeneration logic into configurable rates per resource.
+- Implement persistence for new data fields through **DataService**.
+- Review client state synchronization after service mutations.
+

--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -51,8 +51,8 @@ The table below lists core modules grouped by network layer and their current st
 |Server|`server/services/AbilityService.ts`|Under Construction|Handles ability activation and cooldowns|
 |Server|`server/services/StatusEffectService.ts`|Under Construction|Refactored to use StatusEffects|
 |Server|`server/services/ResourcesService.ts`|Under Construction|Tracks player resource values - bug fix for static call|
+|Server|`server/services/AttributesService.ts`|Under Construction|Validates attribute changes|
 |Server|`server/entity/npc/NPC.ts`|Usable|NPC instance with random names|
-|Server|`server/entity/player/SoulPlayer.ts`|Usable|Player data container|
 |Server|`server/entity/entityResource/EntityResource.ts`|Usable|Drops collectible resource|
 
 Keep this summary updated whenever modules are added or changed.

--- a/src/server/main.server.ts
+++ b/src/server/main.server.ts
@@ -17,7 +17,6 @@ import {
 	SettingsService,
 } from "./services";
 
-//import SoulPlayer from "./classes/player/SoulPlayer";
 
 /* =============================================== Initialization ========================================= */
 DataProfileController.Start();
@@ -26,17 +25,6 @@ BattleRoomService.Start();
 ResourcesService.Start();
 SettingsService.Start();
 //OrganismFood.SpawnResource(new CFrame(0, 10, 0));
-
-// /* ================== Player Joined Event ================== */
-// Players.PlayerAdded.Connect((player) => {
-// 	if (SoulPlayer.GetSoulPlayer(player)) {
-// 		warn(`SoulPlayer already exists for ${player.Name}.`);
-// 		return;
-// 	}
-// 	const character = player.Character || player.CharacterAdded.Wait()[0];
-// 	/* Create a new SoulPlayer instance */
-// 	new SoulPlayer(player, character);
-// });
 
 // task.spawn(() => {
 // 	while (Players.GetPlayers().size() >= 0) {

--- a/src/server/network/listener.server.ts
+++ b/src/server/network/listener.server.ts
@@ -25,14 +25,14 @@ import { HttpService } from "@rbxts/services";
 import { ClientDispatch, Network, TestNetwork } from "shared/network";
 
 /* Custom Services */
-import { BattleRoomService, SettingsService, NPCService, AbilityService, DataProfileController } from "server/services";
+import { BattleRoomService, SettingsService, NPCService, AbilityService, DataProfileController, AttributesService } from "server/services";
 
 /* Factories and Types */
 import { AttributeKey, AbilityKey, SettingKey, NPCKey, ProfileDataKey } from "shared/definitions";
 
 // Attibutes -----------------------------------------------------
 Network.Server.OnEvent("IncreaseAttribute", (player, attributeKey: AttributeKey, amount: number) => {
-	//AttributeService.Increase(player, attributeKey, amount);
+        AttributesService.Increase(player, attributeKey, amount);
 });
 
 // Resources -----------------------------------------------------
@@ -82,11 +82,11 @@ TestNetwork.Server.OnEvent("SPAWN_NPC", (player, npcKey: NPCKey) => {
 });
 
 ClientDispatch.Server.Get("GetData").SetCallback((player, dataKey: ProfileDataKey) => {
-	const playerProfile = DataProfileController.GetProfile(player);
-	if (playerProfile === undefined) {
-		warn(`SoulPlayer not found for ${player.Name}`);
-		return undefined;
-	}
+        const playerProfile = DataProfileController.GetProfile(player);
+        if (playerProfile === undefined) {
+                warn(`Profile not found for ${player.Name}`);
+                return undefined;
+        }
 	if (playerProfile.Data[dataKey] === undefined) {
 		warn(`Profile data not found for ${player.Name}: ${dataKey}`);
 		return undefined;

--- a/src/server/services/AGENTS.md
+++ b/src/server/services/AGENTS.md
@@ -29,6 +29,10 @@ Spawns NPC instances and removes them. Mutation methods: `Spawn(key, cFrame)` an
 
 Handles activation of player abilities and manages cooldown timers. Primary mutation: `Activate(player, abilityKey)`.
 
+### AttributesService
+
+Increases and validates player attributes. Key mutation: `Increase(player, attributeKey, amount)` which updates the player's profile and recalculates resources.
+
 ### StatusEffectService
 
 Applies periodic status effects to players. Mutations include `AddEffect(player, effectKey)`, `RemoveEffect(player, effectKey)`, and `ClearEffects(player)`.

--- a/src/server/services/AttributesService.ts
+++ b/src/server/services/AttributesService.ts
@@ -1,0 +1,60 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        AttributesService.ts
+ * @module      AttributesService
+ * @layer       Server/Services
+ * @classType   Singleton
+ * @description Validates and mutates player attribute values.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Codex
+ * @license      MIT
+ * @since        0.2.0
+ * @lastUpdated  2025-07-03 by Codex – Initial creation
+ */
+
+/* =============================================== Imports ===================== */
+import { AttributeKey, clampAttr } from "shared/definitions/ProfileDefinitions/Attributes";
+import { DataProfileController } from "./DataService";
+import { ResourcesService } from "./ResourcesService";
+
+/* =============================================== Service ===================== */
+export class AttributesService {
+    private static _instance: AttributesService | undefined;
+
+    private constructor() {
+        print("AttributesService initialized.");
+    }
+
+    public static Start(): AttributesService {
+        if (!this._instance) {
+            this._instance = new AttributesService();
+        }
+        return this._instance;
+    }
+
+    public static Increase(player: Player, key: AttributeKey, amount: number) {
+        const profile = DataProfileController.GetProfile(player);
+        if (!profile) return;
+        const attrs = profile.Data.Attributes;
+        const newValue = clampAttr(key, attrs[key] + amount);
+        const delta = newValue - attrs[key];
+        if (delta === 0) return;
+        attrs[key] = newValue;
+        attrs.SpentPoints += delta;
+        attrs.AvailablePoints = math.max(attrs.AvailablePoints - delta, 0);
+        ResourcesService.Recalculate(player);
+    }
+
+    public static Get(player: Player) {
+        return DataProfileController.GetProfile(player)?.Data.Attributes;
+    }
+}
+
+// Auto-start on import
+AttributesService.Start();

--- a/src/server/services/index.ts
+++ b/src/server/services/index.ts
@@ -28,3 +28,4 @@ export * from "./NPCService";
 export * from "./AbilityService";
 export * from "./StatusEffectService";
 export * from "./ResourcesService";
+export * from "./AttributesService";

--- a/src/shared/network/Definitions.ts
+++ b/src/shared/network/Definitions.ts
@@ -29,9 +29,7 @@ type GetDataFn = <K extends ProfileDataKey>(dataKey: K) => Promise<ProfileDataMa
 
 /* =============================================== Network Definitions =============================================== */
 export const Network = Net.Definitions.Create({
-	// Get SoulPlayer
-
-	// fire-and-forget from client → server
+        // fire-and-forget from client → server
 	SpawnManifestation: Net.Definitions.ClientToServerEvent<[formId: string, abilityId: string, bonusId: string]>(),
 	IncreaseAttribute: Net.Definitions.ClientToServerEvent<[attributeKey: AttributeKey, amount: number]>(),
 	AddGem: Net.Definitions.ClientToServerEvent<[gemid: string]>(),


### PR DESCRIPTION
## Summary
- migrate to services-only architecture by removing remaining `SoulPlayer` references
- add `AttributesService` for server-side attribute updates
- wire attribute changes through network listener
- update services documentation and development summary
- clean up network definitions and create NEXTSTEPS_TODO

## Testing
- `npm run lint` *(fails: warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_6867daca0c0483279251839791741066