### PR TITLE
Finalize network dispatch services

### DIFF
--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -31,7 +31,7 @@ The table below lists core modules grouped by network layer and their current st
 |Client|`client/ui/molecules/TitleBar.ts`|Usable|Window title bar component|
 |Client|`client/ui/molecules/SettingListItem.ts`|Usable|Displays and edits a single setting|
 |Client|`client/states/SettingsState.ts`|Usable|Reactive settings container|
-|Client|`client/network/CallServer.ts`|Usable|Client RPC helpers|
+|Client|`client/network/ClientNetworkService.ts`|Usable|Client RPC helpers|
 |Client|`client/network/listener.client.ts`|Usable|Receives server events|
 |Client|`client/ui/screens`|Under Construction|Gem forge, character, inventory, shop, settings, teleport and HUD screens|
 |Client|`client/ui/screens/DragDropScreen.ts`|Usable|Drag and drop demo|

--- a/src/client/network/ClientNetworkService.ts
+++ b/src/client/network/ClientNetworkService.ts
@@ -1,23 +1,13 @@
 /// <reference types="@rbxts/types" />
 
 /**
- * @file        ClientDispatch.ts
- * @module      ClientDispatch
+ * @file        ClientNetworkService.ts
+ * @module      ClientNetworkService
  * @layer       Client/Network
  * @description Thin wrappers around client network calls.
  */
 
-import Net from "@rbxts/net";
-import { Players } from "@rbxts/services";
-import {
-	AbilityKey,
-	SettingKey,
-	PlayerSettings,
-	ProfileDataKey,
-	ProfileDataMap,
-	ClientDispatch,
-	AttributeKey,
-} from "shared";
+import { AbilityKey, SettingKey, ProfileDataKey, ProfileDataMap, ClientDispatch, AttributeKey } from "shared";
 
 /* Event Signals */
 const ActivateAbilitySignal = ClientDispatch.Client.Get("ActivateAbility");

--- a/src/client/network/index.ts
+++ b/src/client/network/index.ts
@@ -10,4 +10,4 @@
  * @lastUpdated  2025-07-05 by Luminesa – initial header add
  */
 
-export * from "./ClientDispatch";
+export * from "./ClientNetworkService";

--- a/src/client/states/PlayerState.ts
+++ b/src/client/states/PlayerState.ts
@@ -11,7 +11,7 @@ import {
 } from "shared/definitions";
 import { ResourceKey, RESOURCE_KEYS, DEFAULT_RESOURCES } from "shared/definitions/Resources";
 import { StatusEffect } from "shared/definitions/StatusEffect";
-import { GetProfileData } from "client/network/ClientDispatch";
+import { GetProfileData } from "client/network/ClientNetworkService";
 
 /**
  * @file        src/client/states/PlayerState.ts

--- a/src/client/states/SettingsState.ts
+++ b/src/client/states/SettingsState.ts
@@ -19,7 +19,7 @@ import {
 	SETTING_KEYS,
 	SettingKey,
 } from "shared/definitions/ProfileDefinitions/Settings";
-import { GetProfileData } from "client/network/ClientDispatch";
+import { GetProfileData } from "client/network/ClientNetworkService";
 
 export default class SettingsState {
 	private static instance: SettingsState;

--- a/src/client/ui/molecules/Button/AbilityButton.ts
+++ b/src/client/ui/molecules/Button/AbilityButton.ts
@@ -22,7 +22,7 @@ import { Layout } from "client/ui/tokens";
 import { BarMeter } from "client/ui/molecules/FillBar";
 import { CooldownTimer } from "shared/classes/CooldownTimer";
 import { GameImages } from "shared";
-import { ActivateAbility } from "client/network/ClientDispatch";
+import { ActivateAbility } from "client/network/ClientNetworkService";
 
 export interface AbilityButtonProps {
 	abilityKey: AbilityKey;

--- a/src/shared/AGENTS.md
+++ b/src/shared/AGENTS.md
@@ -8,8 +8,8 @@
    - Example: `Attributes.ts` defines player attributes, metadata for UI, and helper types and methods.
 2. Network
     - Handles communication between client and server.
-    - Example: `ServerDispatch.ts` defines server-side events and methods to send updates to clients.
-    - Example: `ClientDispatch.ts` defines client-side methods to request data from the server
+    - Example: `ServerNetwork.ts` defines server-side events and methods to send updates to clients.
+    - Example: `ClientNetworkService.ts` defines client-side methods to request data from the server
 3. Calculations
    - Contains logic for calculating player stats and abilities.
    - Example: `ResourceCalculator.ts` contains functions to calculate player resources like health and mana.


### PR DESCRIPTION
## Summary
- rename `ClientDispatch.ts` to `ClientNetworkService.ts`
- update imports and documentation references
- extend `ServerNetwork` with missing handlers for rooms, gems and settings
- send updated progression and settings data to clients
- document module changes in `AGENTS_DEVELOPMENT_SUMMARY`

## Testing
- `npm run lint:fix`
- `npm run build`
- `npm test`
- `node codexUtility/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_686943c0e9bc83279817279f57832fe9