### PR TITLE
Add AdminButtonBar for service testing

### DIFF
--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -40,6 +40,7 @@ The table below lists core modules grouped by network layer and their current st
 |Client|`client/ui/screens/ShopScreen.ts`|Stub|Item shop window|
 |Client|`client/ui/screens/SettingsScreen.ts`|Stub|Settings window|
 |Client|`client/ui/screens/TeleportScreen.ts`|Stub|Teleport locations window|
+|Client|`client/ui/organisms/ButtonBars/AdminButtonBar.ts`|Under Construction|Admin service test buttons|
 |Server|`server/main.server.ts`|Under Construction|Joins players and loads profiles|
 |Server|`server/network/listener.server.ts`|Usable|Server network handlers|
 |Server|`server/services/DataService.ts`|Usable|Loads player profiles|
@@ -52,6 +53,7 @@ The table below lists core modules grouped by network layer and their current st
 |Server|`server/services/StatusEffectService.ts`|Under Construction|Refactored to use StatusEffects|
 |Server|`server/services/ResourcesService.ts`|Under Construction|Tracks player resource values - bug fix for static call|
 |Server|`server/services/AttributesService.ts`|Under Construction|Validates attribute changes|
+|Server|`server/services/ProgressionService.ts`|Under Construction|Manages experience and level ups|
 |Server|`server/entity/npc/NPC.ts`|Usable|NPC instance with random names|
 |Server|`server/entity/entityResource/EntityResource.ts`|Usable|Drops collectible resource|
 

--- a/src/client/network/ClientNetworkService.ts
+++ b/src/client/network/ClientNetworkService.ts
@@ -25,6 +25,7 @@ import { AbilityKey, SettingKey, ProfileDataKey, ProfileDataMap, ClientDispatch,
 /* Event Signals */
 const ActivateAbilitySignal = ClientDispatch.Client.Get("ActivateAbility");
 const IncreaseAttributeSignal = ClientDispatch.Client.Get("IncreaseAttribute");
+const AddExperienceSignal = ClientDispatch.Client.Get("AddExperience");
 const UpdateSettingSignal = ClientDispatch.Client.Get("UpdatePlayerSetting");
 
 /* Function Signals */
@@ -42,9 +43,13 @@ export function UpdatePlayerSetting(key: SettingKey, value: boolean | string): v
 }
 
 export function ActivateAbility(abilityKey: AbilityKey): boolean {
-	return ActivateAbilitySignal.CallServer(abilityKey);
+        return ActivateAbilitySignal.CallServer(abilityKey);
 }
 export async function IncreaseAttribute(attributeKey: AttributeKey, amount: number): Promise<void> {
-	print(`CallServer: IncreaseAttribute(${attributeKey}, ${amount}) called.`);
-	await IncreaseAttributeSignal.SendToServer(attributeKey, amount);
+        print(`CallServer: IncreaseAttribute(${attributeKey}, ${amount}) called.`);
+        await IncreaseAttributeSignal.SendToServer(attributeKey, amount);
+}
+
+export function AddExperience(amount: number): void {
+        AddExperienceSignal.SendToServer(amount);
 }

--- a/src/client/ui/organisms/ButtonBars/AdminButtonBar.ts
+++ b/src/client/ui/organisms/ButtonBars/AdminButtonBar.ts
@@ -1,0 +1,25 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        AdminButtonBar.ts
+ * @module      AdminButtonBar
+ * @layer       Client/UI/Organisms
+ * @description Horizontal bar of service test buttons for administrators.
+ */
+
+import { GamePanel } from "client/ui/atoms";
+import { Layout } from "client/ui/tokens";
+import { AttributeServiceButton, ProgressionServiceButton, AbilityServiceButton } from "../ServicesButtons";
+
+export const AdminButtonBar = () =>
+        GamePanel({
+                Name: "AdminButtonBar",
+                Size: UDim2.fromOffset(380, 50),
+                BackgroundTransparency: 0.5,
+                Layout: Layout.HorizontalSet(5),
+                Content: {
+                        Attribute: AttributeServiceButton(),
+                        Progression: ProgressionServiceButton(),
+                        Ability: AbilityServiceButton(),
+                },
+        });

--- a/src/client/ui/organisms/ButtonBars/index.ts
+++ b/src/client/ui/organisms/ButtonBars/index.ts
@@ -1,2 +1,4 @@
 export * from "./AbilityBar";
 export * from "./HUDMenuBar";
+export * from "./AdminButtonBar";
+export * from "../ServicesButtons";

--- a/src/client/ui/organisms/ServicesButtons/AbilityServiceButton.ts
+++ b/src/client/ui/organisms/ServicesButtons/AbilityServiceButton.ts
@@ -1,0 +1,22 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        AbilityServiceButton.ts
+ * @module      AbilityServiceButton
+ * @layer       Client/UI/Organisms
+ * @description Button for invoking AbilityService test actions.
+ */
+
+import { GameButton } from "client/ui/atoms";
+import { ActivateAbility } from "client/network/ClientNetworkService";
+
+export const AbilityServiceButton = () =>
+        GameButton({
+                Name: "AbilityServiceButton",
+                Size: new UDim2(0, 120, 0, 40),
+                Image: "rbxassetid://8672979592",
+                Label: "Use Fireball",
+                OnClick: () => {
+                        ActivateAbility("fireball");
+                },
+        });

--- a/src/client/ui/organisms/ServicesButtons/AttributeServiceButton.ts
+++ b/src/client/ui/organisms/ServicesButtons/AttributeServiceButton.ts
@@ -1,0 +1,22 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        AttributeServiceButton.ts
+ * @module      AttributeServiceButton
+ * @layer       Client/UI/Organisms
+ * @description Button for invoking AttributeService test actions.
+ */
+
+import { GameButton } from "client/ui/atoms";
+import { IncreaseAttribute } from "client/network/ClientNetworkService";
+
+export const AttributeServiceButton = () =>
+        GameButton({
+                Name: "AttributeServiceButton",
+                Size: new UDim2(0, 120, 0, 40),
+                Image: "rbxassetid://8672979592",
+                Label: "Add STR",
+                OnClick: () => {
+                        IncreaseAttribute("str", 1);
+                },
+        });

--- a/src/client/ui/organisms/ServicesButtons/ProgressionServiceButton.ts
+++ b/src/client/ui/organisms/ServicesButtons/ProgressionServiceButton.ts
@@ -1,0 +1,22 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        ProgressionServiceButton.ts
+ * @module      ProgressionServiceButton
+ * @layer       Client/UI/Organisms
+ * @description Button for invoking ProgressionService test actions.
+ */
+
+import { GameButton } from "client/ui/atoms";
+import { AddExperience } from "client/network/ClientNetworkService";
+
+export const ProgressionServiceButton = () =>
+        GameButton({
+                Name: "ProgressionServiceButton",
+                Size: new UDim2(0, 120, 0, 40),
+                Image: "rbxassetid://8672979592",
+                Label: "+10 XP",
+                OnClick: () => {
+                        AddExperience(10);
+                },
+        });

--- a/src/client/ui/organisms/ServicesButtons/index.ts
+++ b/src/client/ui/organisms/ServicesButtons/index.ts
@@ -1,0 +1,3 @@
+export * from "./AttributeServiceButton";
+export * from "./ProgressionServiceButton";
+export * from "./AbilityServiceButton";

--- a/src/client/ui/screens/PlayerHUDScreen.ts
+++ b/src/client/ui/screens/PlayerHUDScreen.ts
@@ -8,7 +8,7 @@
  */
 
 import { GamePanel, GameScreen } from "../atoms";
-import { HUDMenuBar, AbilityBarComponent } from "client/ui/organisms";
+import { HUDMenuBar, AbilityBarComponent, AdminButtonBar } from "client/ui/organisms";
 import { CharacterInfoCard } from "../organisms";
 import { Layout, Padding } from "../tokens";
 import { SCREEN_KEYS } from "client/states";
@@ -44,14 +44,13 @@ export const PlayerHUDScreen = () => {
 				Name: "LeftPanel",
 				Size: new UDim2(0.5, 0, 1, 0),
 				BackgroundTransparency: 1,
-				Content: {
-					CharacterInfoCard: HudProps.CharacterInfoCard,
-					MenuBar: HudProps.HUDMenuBar,
-				},
-			}),
-			AbilityBar: AbilityBarComponent(),
-			//AdminBar: AdminBar(Value(false)), // Admin bar visibility controlled by a Value
-			StatusPanel: StatusPanel(PlayerState.getInstance().StatusEffects), // Status effects will be dynamically updated
+                                Content: {
+                                        CharacterInfoCard: HudProps.CharacterInfoCard,
+                                        MenuBar: HudProps.HUDMenuBar,
+                                        AdminBar: AdminButtonBar(),
+                                },
+                        }),
+			AbilityBar: AbilityBarComponent(),			StatusPanel: StatusPanel(PlayerState.getInstance().StatusEffects), // Status effects will be dynamically updated
 		},
 	});
 

--- a/src/server/network/ServerNetwork.ts
+++ b/src/server/network/ServerNetwork.ts
@@ -25,10 +25,11 @@ import {
 	NPCService,
 	ManifestationForgeService,
 	ResourcesService,
-	BattleRoomService,
-	SettingsService,
-	AbilityService,
-	StatusEffectService,
+        BattleRoomService,
+        SettingsService,
+        AbilityService,
+        StatusEffectService,
+        ProgressionService,
 } from "server/services";
 import { AdminNet, ClientDispatch, ServerDispatch } from "shared/network/Definitions";
 
@@ -42,6 +43,7 @@ const AbilitiesUpdated = ServerDispatch.Server.Get("AbilitiesUpdated");
 const GetProfileDataSignal = ClientDispatch.Server.Get("GetData");
 /* Attributes */
 const IncreaseAttributeSignal = ClientDispatch.Server.Get("IncreaseAttribute");
+const AddExperienceSignal = ClientDispatch.Server.Get("AddExperience");
 const CreateRoomSignal = ClientDispatch.Server.Get("CreateRoom");
 const JoinRoomSignal = ClientDispatch.Server.Get("JoinRoom");
 const AddGemSignal = ClientDispatch.Server.Get("AddGem");
@@ -152,9 +154,19 @@ ActivateAbilitySignal.SetCallback((player: Player, abilityKey: AbilityKey) => {
  * @param amount - The amount to increase the attribute by.
  */
 IncreaseAttributeSignal.Connect((player: Player, attributeKey: AttributeKey, amount: number) => {
-	//print(`Increasing attribute for player ${player.Name}: ${attributeKey} by ${amount}`);
-	AttributesService.Increase(player, attributeKey, amount);
-	SendAttributesUpdated(player);
+        //print(`Increasing attribute for player ${player.Name}: ${attributeKey} by ${amount}`);
+        AttributesService.Increase(player, attributeKey, amount);
+        SendAttributesUpdated(player);
+});
+
+/**
+ * @function AddExperienceSignal
+ * @description Adds experience points to a player's progression.
+ * @param player - The player gaining experience.
+ * @param amount - Amount of experience to add.
+ */
+AddExperienceSignal.Connect((player: Player, amount: number) => {
+        ProgressionService.AddExperience(player, amount);
 });
 
 /**

--- a/src/server/services/ProgressionService.ts
+++ b/src/server/services/ProgressionService.ts
@@ -1,0 +1,62 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        ProgressionService.ts
+ * @module      ProgressionService
+ * @layer       Server/Services
+ * @classType   Singleton
+ * @description Handles player experience and level progression.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Codex
+ * @license      MIT
+ * @since        0.2.0
+ * @lastUpdated  2025-07-05 by Codex – Initial creation
+ */
+
+/* =============================================== Imports ================================== */
+import { getNextLevelExperience } from "shared/definitions/ProfileDefinitions/Progression";
+import { DataProfileController } from "./DataService";
+import { SendProgressionUpdated } from "server/network/ServerNetwork";
+
+/* =============================================== Service ================================== */
+export class ProgressionService {
+        private static _instance: ProgressionService | undefined;
+
+        private constructor() {
+                print("ProgressionService initialized.");
+        }
+
+        public static Start(): ProgressionService {
+                if (!this._instance) {
+                        this._instance = new ProgressionService();
+                }
+                return this._instance;
+        }
+
+        /* ------------------------------- Public API ---------------------------------------- */
+        public static AddExperience(player: Player, amount: number) {
+                const profile = DataProfileController.GetProfile(player);
+                if (!profile) return;
+
+                const progression = profile.Data.Progression;
+                progression.Experience += amount;
+                while (progression.Experience >= progression.NextLevelExperience) {
+                        progression.Experience -= progression.NextLevelExperience;
+                        progression.Level += 1;
+                        progression.NextLevelExperience = getNextLevelExperience(progression.Level);
+                }
+                SendProgressionUpdated(player);
+        }
+
+        public static Get(player: Player) {
+                return DataProfileController.GetProfile(player)?.Data.Progression;
+        }
+}
+
+// Auto-start on import
+ProgressionService.Start();

--- a/src/server/services/index.ts
+++ b/src/server/services/index.ts
@@ -41,3 +41,4 @@ export * from "./AbilityService";
 export * from "./StatusEffectService";
 export * from "./ResourcesService";
 export * from "./AttributesService";
+export * from "./ProgressionService";

--- a/src/shared/network/Definitions.ts
+++ b/src/shared/network/Definitions.ts
@@ -44,6 +44,9 @@ export const ClientDispatch = Net.Definitions.Create({
 	/* --------------------------------------------- Attributes --------------------------------------------- */
 	IncreaseAttribute: Net.Definitions.ClientToServerEvent<[attributeKey: AttributeKey, amount: number]>(),
 
+        /* --------------------------------------------- Progression -------------------------------------- */
+        AddExperience: Net.Definitions.ClientToServerEvent<[amount: number]>(),
+
 	/* --------------------------------------------- Abilities ------------------------------------------------- */
 	ActivateAbility: Net.Definitions.ServerFunction<(abilityKey: AbilityKey) => boolean>(),
 


### PR DESCRIPTION
## Summary
- implement `ProgressionService` for server-side XP handling
- add `AddExperience` network event and handlers
- expose new ClientNetworkService helper
- create service buttons and `AdminButtonBar` organism
- display AdminButtonBar on PlayerHUD screen
- update development summary

## Testing
- `node codexUtility/runTests.js` *(fails: rbxtsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_686953628ac483278da9ccabe385f003