### PR TITLE
Refactor PlayerState into slices

### DIFF
--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -44,6 +44,10 @@ The table below lists core modules grouped by network layer and their current st
 |Client|`client/ui/molecules/Button/AbilityButton.ts`|Usable|Ability icon with cooldown|
 |Client|`client/ui/organisms/ButtonBars/AbilityBar.ts`|Under Construction|Displays equipped abilities|
 |Client|`client/states/AbilitySlice.ts`|Under Construction|Ability list and actions|
+|Client|`client/states/AttributesSlice.ts`|Under Construction|Attribute values and points|
+|Client|`client/states/ResourceSlice.ts`|Under Construction|Player resource values|
+|Client|`client/states/ProgressionSlice.ts`|Under Construction|Level and experience|
+|Client|`client/states/CurrencySlice.ts`|Stub|Currency amounts|
 |Server|`server/main.server.ts`|Under Construction|Joins players and loads profiles|
 |Server|`server/network/listener.server.ts`|Usable|Server network handlers|
 |Server|`server/services/DataService.ts`|Usable|Loads player profiles|

--- a/src/client/states/AttributesSlice.ts
+++ b/src/client/states/AttributesSlice.ts
@@ -1,0 +1,64 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        AttributesSlice.ts
+ * @module      AttributesSlice
+ * @layer       Client/State
+ * @description Reactive container for player attribute values.
+ */
+
+import { Value } from "@rbxts/fusion";
+import {
+    ATTR_KEYS,
+    AttributeKey,
+    AttributesDTO,
+    DefaultAttributes,
+} from "shared/definitions/ProfileDefinitions/Attributes";
+import { ServerDispatch } from "shared/network/Definitions";
+import { CNet } from "client/network/ClientNetworkService";
+
+export default class AttributesSlice {
+    private static instance: AttributesSlice;
+
+    public readonly Attributes: Record<AttributeKey, Value<number>> = {} as never;
+    public readonly Available = Value(0);
+    public readonly Spent = Value(0);
+
+    private constructor() {
+        for (const key of ATTR_KEYS) {
+            this.Attributes[key] = Value(DefaultAttributes[key]);
+        }
+        this.Available.set(DefaultAttributes.AvailablePoints);
+        this.Spent.set(DefaultAttributes.SpentPoints);
+        this.fetchFromServer();
+        this.setupListeners();
+    }
+
+    private async fetchFromServer() {
+        const attrs = (await CNet.GetProfileData("Attributes")) as AttributesDTO | undefined;
+        if (attrs) {
+            for (const key of ATTR_KEYS) {
+                this.Attributes[key].set(attrs[key]);
+            }
+            this.Available.set(attrs.AvailablePoints);
+            this.Spent.set(attrs.SpentPoints);
+        }
+    }
+
+    private setupListeners() {
+        ServerDispatch.Client.Get("AttributesUpdated").Connect((data) => {
+            for (const key of ATTR_KEYS) {
+                this.Attributes[key].set(data[key]);
+            }
+            this.Available.set(data.AvailablePoints);
+            this.Spent.set(data.SpentPoints);
+        });
+    }
+
+    public static getInstance(): AttributesSlice {
+        if (!this.instance) {
+            this.instance = new AttributesSlice();
+        }
+        return this.instance;
+    }
+}

--- a/src/client/states/CurrencySlice.ts
+++ b/src/client/states/CurrencySlice.ts
@@ -1,0 +1,30 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        CurrencySlice.ts
+ * @module      CurrencySlice
+ * @layer       Client/State
+ * @description Reactive container for player currency amounts.
+ */
+
+import { Value } from "@rbxts/fusion";
+import { CURRENCY_KEY, CurrencyKey, DefaultCurrency } from "shared/definitions/ProfileDefinitions/Currency";
+
+export default class CurrencySlice {
+    private static instance: CurrencySlice;
+
+    public readonly Currency: Record<CurrencyKey, Value<number>> = {} as never;
+
+    private constructor() {
+        for (const key of CURRENCY_KEY) {
+            this.Currency[key] = Value(DefaultCurrency[key]);
+        }
+    }
+
+    public static getInstance(): CurrencySlice {
+        if (!this.instance) {
+            this.instance = new CurrencySlice();
+        }
+        return this.instance;
+    }
+}

--- a/src/client/states/PlayerState.ts
+++ b/src/client/states/PlayerState.ts
@@ -1,126 +1,38 @@
-import Fusion, { Observer, Value, Computed } from "@rbxts/fusion";
-import {
-	AbilityKey,
-	AttributeKey,
-	ATTR_KEYS,
-	AttributesDTO,
-	DefaultAttributes,
-	CurrencyKey,
-	CURRENCY_KEY,
-	DefaultCurrency,
-} from "shared/definitions";
-import { ResourceKey, RESOURCE_KEYS, DEFAULT_RESOURCES } from "shared/definitions/Resources";
-import { StatusEffect } from "shared/definitions/StatusEffect";
-import { CNet } from "client/network/ClientNetworkService";
+/// <reference types="@rbxts/types" />
 
 /**
- * @file        src/client/states/PlayerState.ts
+ * @file        PlayerState.ts
  * @module      PlayerState
- * @layer       Client
- * @description Defines the player's health, mana, and stamina states.
- *
- * ╭───────────────────────────────╮
- * │  Soul Steel · Coding Guide    │
- * │  Fusion v4 · Strict TS · ECS  │
- * ╰───────────────────────────────╯
- *
- * @author       Trembus
- * @license      MIT
- * @since        0.2.0
- * @lastUpdated  2025-06-25 by Trembus – Initial creation
- *
- * @dependencies
- *   @rbxts/fusion ^0.4.0
+ * @layer       Client/State
+ * @description Lightweight wrapper exposing client state slices.
  */
-export type ResourceState = {
-	Current: Value<number>;
-	Max: Value<number>;
-	Percent: Computed<number>;
-};
+
+import { Value } from "@rbxts/fusion";
+import AbilitySlice from "./AbilitySlice";
+import ResourceSlice from "./ResourceSlice";
+import AttributesSlice from "./AttributesSlice";
+import ProgressionSlice from "./ProgressionSlice";
+import CurrencySlice from "./CurrencySlice";
+import { StatusEffect } from "shared/definitions/StatusEffect";
 
 export default class PlayerState {
-	private static instance: PlayerState;
+    private static instance: PlayerState;
 
-	/** Ability list from the player's profile */
-	public Abilities: Value<AbilityKey[]> = Value([]);
+    public readonly Abilities = AbilitySlice.getInstance();
+    public readonly Resources = ResourceSlice.getInstance();
+    public readonly Attributes = AttributesSlice.getInstance();
+    public readonly Progression = ProgressionSlice.getInstance();
+    public readonly Currency = CurrencySlice.getInstance();
 
-	/** Attribute values and point totals */
-	public Attributes: Record<AttributeKey, Value<number>> = {} as never;
-	public AttributeAvailable = Value(0);
-	public AttributeSpent = Value(0);
+    /** Active status effects */
+    public StatusEffects = Value<StatusEffect[]>([]);
 
-	/** Currency amounts */
-	public Currency: Record<CurrencyKey, Value<number>> = {} as never;
+    private constructor() {}
 
-	/** Active status effects */
-	public StatusEffects = Value<StatusEffect[]>([]);
-
-	/** Player resource values */
-	public Resources: Record<ResourceKey, ResourceState> = {} as never;
-
-	private constructor() {
-		PlayerState.instance = this;
-
-		// initialize attribute values
-		for (const key of ATTR_KEYS) {
-			this.Attributes[key] = Value(DefaultAttributes[key]);
-		}
-		this.AttributeAvailable.set(DefaultAttributes.AvailablePoints);
-		this.AttributeSpent.set(DefaultAttributes.SpentPoints);
-
-		// initialize currency
-		for (const key of CURRENCY_KEY) {
-			this.Currency[key] = Value(DefaultCurrency[key]);
-		}
-
-		// initialize resources using defaults
-		for (const key of RESOURCE_KEYS) {
-			const data = DEFAULT_RESOURCES[key];
-			const current = Value(data.current);
-			const max = Value(data.max);
-			this.Resources[key] = {
-				Current: current,
-				Max: max,
-				Percent: Computed(() => current.get() / math.max(max.get(), 1)),
-			};
-		}
-
-		//this.debugObserverInit();
-		this.fetchFromServer(); // Fetch initial data from the server
-	}
-
-	private debugObserverInit() {
-		const inst = PlayerState.getInstance();
-		const res = inst.Resources;
-		Observer(res.Health.Current).onChange(() => {
-			print(`Health: ${res.Health.Current.get()}/${res.Health.Max.get()}`);
-		});
-		Observer(res.Mana.Current).onChange(() => {
-			print(`Mana: ${res.Mana.Current.get()}/${res.Mana.Max.get()}`);
-		});
-		Observer(res.Stamina.Current).onChange(() => {
-			print(`Stamina: ${res.Stamina.Current.get()}/${res.Stamina.Max.get()}`);
-		});
-	}
-
-	private async fetchFromServer() {
-		this.Abilities.set((await CNet.GetAbilities()) ?? []);
-
-		const attrs = await CNet.GetProfileData("Attributes");
-		if (attrs) {
-			const data = attrs as AttributesDTO;
-			for (const key of ATTR_KEYS) {
-				this.Attributes[key].set(data[key]);
-			}
-			this.AttributeAvailable.set(data.AvailablePoints);
-			this.AttributeSpent.set(data.SpentPoints);
-		}
-	}
-
-	public static getInstance(): PlayerState {
-		if (!PlayerState.instance) {
-			PlayerState.instance = new PlayerState();
-		}
-		return PlayerState.instance;
-	}
+    public static getInstance(): PlayerState {
+        if (!this.instance) {
+            this.instance = new PlayerState();
+        }
+        return this.instance;
+    }
 }

--- a/src/client/states/ProgressionSlice.ts
+++ b/src/client/states/ProgressionSlice.ts
@@ -1,0 +1,56 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        ProgressionSlice.ts
+ * @module      ProgressionSlice
+ * @layer       Client/State
+ * @description Reactive container for level and experience values.
+ */
+
+import { Value } from "@rbxts/fusion";
+import {
+    PROGRESSION_KEYS,
+    ProgressionKey,
+    ProgressionDTO,
+    DefaultProgression,
+} from "shared/definitions/ProfileDefinitions/Progression";
+import { CNet } from "client/network/ClientNetworkService";
+import { ServerDispatch } from "shared/network/Definitions";
+
+export default class ProgressionSlice {
+    private static instance: ProgressionSlice;
+
+    public readonly Progression: Record<ProgressionKey, Value<number>> = {} as never;
+
+    private constructor() {
+        for (const key of PROGRESSION_KEYS) {
+            this.Progression[key] = Value(DefaultProgression[key]);
+        }
+        this.fetchFromServer();
+        this.setupListeners();
+    }
+
+    private async fetchFromServer() {
+        const data = (await CNet.GetProfileData("Progression")) as ProgressionDTO | undefined;
+        if (data) {
+            for (const key of PROGRESSION_KEYS) {
+                this.Progression[key].set(data[key]);
+            }
+        }
+    }
+
+    private setupListeners() {
+        ServerDispatch.Client.Get("ProgressionUpdated").Connect((progress) => {
+            for (const key of PROGRESSION_KEYS) {
+                this.Progression[key].set(progress[key]);
+            }
+        });
+    }
+
+    public static getInstance(): ProgressionSlice {
+        if (!this.instance) {
+            this.instance = new ProgressionSlice();
+        }
+        return this.instance;
+    }
+}

--- a/src/client/states/ResourceSlice.ts
+++ b/src/client/states/ResourceSlice.ts
@@ -1,0 +1,55 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        ResourceSlice.ts
+ * @module      ResourceSlice
+ * @layer       Client/State
+ * @description Reactive container for player resources like health and mana.
+ */
+
+import { Value, Computed } from "@rbxts/fusion";
+import { ResourceKey, RESOURCE_KEYS, DEFAULT_RESOURCES } from "shared/definitions/Resources";
+import { ServerDispatch } from "shared/network/Definitions";
+
+export type ResourceState = {
+    Current: Value<number>;
+    Max: Value<number>;
+    Percent: Computed<number>;
+};
+
+export default class ResourceSlice {
+    private static instance: ResourceSlice;
+
+    public readonly Resources: Record<ResourceKey, ResourceState> = {} as never;
+
+    private constructor() {
+        for (const key of RESOURCE_KEYS) {
+            const data = DEFAULT_RESOURCES[key];
+            const current = Value(data.current);
+            const max = Value(data.max);
+            this.Resources[key] = {
+                Current: current,
+                Max: max,
+                Percent: Computed(() => current.get() / math.max(max.get(), 1)),
+            };
+        }
+        this.setupListeners();
+    }
+
+    private setupListeners() {
+        ServerDispatch.Client.Get("ResourceUpdated").Connect((key, current, max) => {
+            const res = this.Resources[key];
+            if (res) {
+                res.Current.set(current);
+                res.Max.set(max);
+            }
+        });
+    }
+
+    public static getInstance(): ResourceSlice {
+        if (!this.instance) {
+            this.instance = new ResourceSlice();
+        }
+        return this.instance;
+    }
+}

--- a/src/client/states/index.ts
+++ b/src/client/states/index.ts
@@ -5,25 +5,14 @@
  * @module      states
  * @layer       Shared
  * @description Barrel index file for the shared states module, exporting all state management utilities.
- *
- * ╭───────────────────────────────╮
- * │  Soul Steel · Coding Guide    │
- * │  Fusion v4 · Strict TS · ECS  │
- * ╰───────────────────────────────╯
- *
- * @author       Trembus
- * @license      MIT
- * @since        0.2.0
- * @lastUpdated  2025-06-25 by Trembus – Initial creation
- *
- * @dependencies
- *   @rbxts/fusion ^0.4.0
  */
 
-// export * from "./GemForgeState";
-// export * from "./InventoryState";
 export * from "./PlayerState";
 export * from "./ScreenState";
 export * from "./ThemeState";
 export { default as SettingsState } from "./SettingsState";
 export { default as AbilitySlice } from "./AbilitySlice";
+export { default as ResourceSlice } from "./ResourceSlice";
+export { default as AttributesSlice } from "./AttributesSlice";
+export { default as ProgressionSlice } from "./ProgressionSlice";
+export { default as CurrencySlice } from "./CurrencySlice";

--- a/src/client/ui/organisms/ResourceBar.ts
+++ b/src/client/ui/organisms/ResourceBar.ts
@@ -24,15 +24,13 @@
 // -------------- Imports ----------------------------------------------------- //
 import { GamePanel } from "client/ui/atoms"; // absolute alias
 import { BarMeter } from "client/ui/molecules/FillBar/BarMeter";
-import PlayerState from "client/states/PlayerState";
+import ResourceSlice from "client/states/ResourceSlice";
 import { ResourceKey, ResourceMeta } from "shared/definitions/Resources";
 import { Computed } from "@rbxts/fusion";
 
 // -------------- Local helpers --------------------------------------------- //
 export function ResourceBar(resourceKey: ResourceKey) {
-	const playerState = PlayerState.getInstance();
-
-	const state = playerState.Resources[resourceKey];
+    const state = ResourceSlice.getInstance().Resources[resourceKey];
 	const meta = ResourceMeta[resourceKey];
 	const resourceBarContainer = GamePanel({
 		Name: `${resourceKey}BarContainer`,


### PR DESCRIPTION
## Summary
- implement ResourceSlice, AttributesSlice, ProgressionSlice and CurrencySlice
- wrap slices in PlayerState and update barrel exports
- adjust ResourceBar organism to use ResourceSlice
- document new modules in AGENTS_DEVELOPMENT_SUMMARY

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686beffaddc88327bf91b9decd1e25b9