### PR TITLE
Add progression UI components

### DIFF
--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -30,6 +30,8 @@ The table below lists core modules grouped by network layer and their current st
 |Client|`client/ui/molecules/GameWindow.ts`|Usable|Panel window with title bar|
 |Client|`client/ui/molecules/TitleBar.ts`|Usable|Window title bar component|
 |Client|`client/ui/molecules/SettingListItem.ts`|Usable|Displays and edits a single setting|
+|Client|`client/ui/molecules/ExperienceBar.ts`|Usable|Displays experience progress|
+|Client|`client/ui/molecules/LevelGem.ts`|Usable|Shows current level|
 |Client|`client/states/SettingsState.ts`|Usable|Reactive settings container|
 |Client|`client/network/ClientNetworkService.ts`|Usable|Client RPC helpers|
 |Client|`client/network/listener.client.ts`|Usable|Receives server events|
@@ -42,11 +44,12 @@ The table below lists core modules grouped by network layer and their current st
 |Client|`client/ui/screens/TeleportScreen.ts`|Stub|Teleport locations window|
 |Client|`client/ui/organisms/ButtonBars/AdminButtonBar.ts`|Under Construction|Admin service test buttons|
 |Client|`client/ui/molecules/Button/AbilityButton.ts`|Usable|Ability icon with cooldown|
+|Client|`client/ui/organisms/ProgressionCard.ts`|Usable|Level and experience UI|
 |Client|`client/ui/organisms/ButtonBars/AbilityBar.ts`|Under Construction|Displays equipped abilities|
 |Client|`client/states/AbilitySlice.ts`|Under Construction|Ability list and actions|
 |Client|`client/states/AttributesSlice.ts`|Under Construction|Attribute values and points|
 |Client|`client/states/ResourceSlice.ts`|Under Construction|Player resource values|
-|Client|`client/states/ProgressionSlice.ts`|Under Construction|Level and experience|
+|Client|`client/states/ProgressionSlice.ts`|Usable|Level and experience slice|
 |Client|`client/states/CurrencySlice.ts`|Stub|Currency amounts|
 |Server|`server/main.server.ts`|Under Construction|Joins players and loads profiles|
 |Server|`server/network/listener.server.ts`|Usable|Server network handlers|

--- a/src/client/states/ProgressionSlice.ts
+++ b/src/client/states/ProgressionSlice.ts
@@ -7,7 +7,7 @@
  * @description Reactive container for level and experience values.
  */
 
-import { Value } from "@rbxts/fusion";
+import { Value, Computed } from "@rbxts/fusion";
 import {
 	PROGRESSION_KEYS,
 	ProgressionKey,
@@ -20,7 +20,11 @@ import { ServerDispatch } from "shared/network/Definitions";
 export default class ProgressionSlice {
 	private static instance: ProgressionSlice;
 
-	public readonly Progression: Record<ProgressionKey, Value<number>> = {} as never;
+        public readonly Progression: Record<ProgressionKey, Value<number>> = {} as never;
+        public readonly NextLevelExperience = Value(DefaultProgression.NextLevelExperience);
+        public readonly ExperiencePercent = Computed(() =>
+                this.Progression.Experience.get() / math.max(this.NextLevelExperience.get(), 1),
+        );
 
 	private constructor() {
 		for (const key of PROGRESSION_KEYS) {
@@ -30,22 +34,24 @@ export default class ProgressionSlice {
 		this.setupListeners();
 	}
 
-	private async fetchFromServer() {
-		const data = (await CNet.GetProfileData("Progression")) as ProgressionDTO | undefined;
-		if (data) {
-			for (const key of PROGRESSION_KEYS) {
-				this.Progression[key].set(data[key]);
-			}
-		}
-	}
+        private async fetchFromServer() {
+                const data = (await CNet.GetProfileData("Progression")) as ProgressionDTO | undefined;
+                if (data) {
+                        for (const key of PROGRESSION_KEYS) {
+                                this.Progression[key].set(data[key]);
+                        }
+                        this.NextLevelExperience.set(data.NextLevelExperience);
+                }
+        }
 
 	private setupListeners() {
-		ServerDispatch.Client.Get("ProgressionUpdated").Connect((progress) => {
-			for (const key of PROGRESSION_KEYS) {
-				this.Progression[key].set(progress[key]);
-			}
-		});
-	}
+                ServerDispatch.Client.Get("ProgressionUpdated").Connect((progress) => {
+                        for (const key of PROGRESSION_KEYS) {
+                                this.Progression[key].set(progress[key]);
+                        }
+                        this.NextLevelExperience.set(progress.NextLevelExperience);
+                });
+        }
 
 	public static getInstance(): ProgressionSlice {
 		if (!this.instance) {

--- a/src/client/ui/molecules/ExperienceBar.ts
+++ b/src/client/ui/molecules/ExperienceBar.ts
@@ -1,0 +1,55 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        ExperienceBar.ts
+ * @module      ExperienceBar
+ * @layer       Client/UI/Molecules
+ * @description Horizontal bar displaying current experience progress.
+ */
+
+import Fusion, { Computed, Observer } from "@rbxts/fusion";
+import { BarMeter } from "./FillBar";
+import ProgressionSlice from "client/states/ProgressionSlice";
+import { ExperienceGradient } from "shared/assets";
+import { getNextLevelExperience } from "shared/definitions/ProfileDefinitions/Progression";
+import { createAudio } from "shared/assets/audio";
+import { TweenService } from "@rbxts/services";
+
+export function ExperienceBar() {
+        const slice = ProgressionSlice.getInstance();
+        const level = slice.Progression.Level;
+        const experience = slice.Progression.Experience;
+
+        const percent = Computed(() => {
+                const lvl = level.get();
+                const exp = experience.get();
+                const nextExp = getNextLevelExperience(lvl);
+                slice.NextLevelExperience.set(nextExp);
+                return exp / math.max(nextExp, 1);
+        });
+
+        const bar = BarMeter({
+                ProgressState: percent,
+                Gradient: ExperienceGradient(),
+                Text: "Experience",
+        });
+
+        const glowTweenInfo = new TweenInfo(0.4, Enum.EasingStyle.Quad, Enum.EasingDirection.Out);
+        const stroke = bar.FindFirstChildWhichIsA("UIStroke");
+        const sound = createAudio("RobotTheme", "LevelUp");
+        sound.Parent = bar;
+
+        Observer(level).onChange(() => {
+                sound.Play();
+                if (stroke) {
+                        stroke.Transparency = 1;
+                        const t = TweenService.Create(stroke, glowTweenInfo, { Transparency: 0 });
+                        t.Play();
+                        t.Completed.Once(() => {
+                                TweenService.Create(stroke, glowTweenInfo, { Transparency: 1 }).Play();
+                        });
+                }
+        });
+
+        return bar;
+}

--- a/src/client/ui/molecules/LevelGem.ts
+++ b/src/client/ui/molecules/LevelGem.ts
@@ -1,0 +1,40 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        LevelGem.ts
+ * @module      LevelGem
+ * @layer       Client/UI/Molecules
+ * @description Displays the player's current level as a gem icon.
+ */
+
+import { GameImage, GamePanel, GameText } from "../atoms";
+import { GameImages } from "shared/assets";
+import { Value, Observer } from "@rbxts/fusion";
+import ProgressionSlice from "client/states/ProgressionSlice";
+
+export function LevelGem() {
+        const level = ProgressionSlice.getInstance().Progression.Level;
+        const labelValue = Value(`Lv ${level.get()}`);
+        Observer(level).onChange(() => {
+                labelValue.set(`Lv ${level.get()}`);
+        });
+
+        return GamePanel({
+                Name: "LevelGem",
+                Size: new UDim2(0, 60, 0, 60),
+                BackgroundTransparency: 1,
+                Content: {
+                        Icon: GameImage({
+                                Image: GameImages.Gems.Epic,
+                                Size: UDim2.fromScale(1, 1),
+                                BackgroundTransparency: 1,
+                        }),
+                        Label: GameText({
+                                TextStateValue: labelValue,
+                                Size: UDim2.fromScale(1, 0.3),
+                                Position: UDim2.fromScale(0, 0.7),
+                                BackgroundTransparency: 1,
+                        }),
+                },
+        });
+}

--- a/src/client/ui/molecules/index.ts
+++ b/src/client/ui/molecules/index.ts
@@ -16,3 +16,5 @@ export * from "./AbilityInfoPanel";
 export * from "./CountdownTimer";
 export * from "./GameWindow";
 export * from "./SettingListItem";
+export * from "./ExperienceBar";
+export * from "./LevelGem";

--- a/src/client/ui/organisms/ProgressionCard.ts
+++ b/src/client/ui/organisms/ProgressionCard.ts
@@ -1,0 +1,26 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        ProgressionCard.ts
+ * @module      ProgressionCard
+ * @layer       Client/Organisms
+ * @description Displays level gem and experience bar together.
+ */
+
+import { GamePanel } from "../atoms";
+import { Layout } from "../tokens";
+import { LevelGem } from "../molecules/LevelGem";
+import { ExperienceBar } from "../molecules/ExperienceBar";
+
+export const ProgressionCard = () => {
+        return GamePanel({
+                Name: "ProgressionCard",
+                Size: new UDim2(0, 250, 0, 70),
+                Layout: Layout.HorizontalSet(5),
+                BackgroundTransparency: 0.5,
+                Content: {
+                        Level: LevelGem(),
+                        XP: ExperienceBar(),
+                },
+        });
+};

--- a/src/client/ui/organisms/index.ts
+++ b/src/client/ui/organisms/index.ts
@@ -13,3 +13,4 @@
 export * from "./ResourceBar";
 export * from "./CharacterInfoCard";
 export * from "./ButtonBars";
+export * from "./ProgressionCard";

--- a/src/shared/assets/gradients.ts
+++ b/src/shared/assets/gradients.ts
@@ -106,13 +106,28 @@ export const GlassGradient = () =>
  * @since 0.2.0
  * 	*/
 export const LavaGradient = () =>
-	New("UIGradient")({
-		Name: "LavaGradient",
-		Color: new ColorSequence([
-			new ColorSequenceKeypoint(0, Color3.fromRGB(255, 85, 0)),
-			new ColorSequenceKeypoint(0.5, Color3.fromRGB(255, 122, 0)),
-			new ColorSequenceKeypoint(1, Color3.fromRGB(255, 0, 0)),
-		]),
-		Transparency: new NumberSequence(0),
-		Rotation: 90,
-	});
+        New("UIGradient")({
+                Name: "LavaGradient",
+                Color: new ColorSequence([
+                        new ColorSequenceKeypoint(0, Color3.fromRGB(255, 85, 0)),
+                        new ColorSequenceKeypoint(0.5, Color3.fromRGB(255, 122, 0)),
+                        new ColorSequenceKeypoint(1, Color3.fromRGB(255, 0, 0)),
+                ]),
+                Transparency: new NumberSequence(0),
+                Rotation: 90,
+        });
+
+/**
+ * Purple-blue gradient used for the experience bar.
+ */
+export const ExperienceGradient = () =>
+        New("UIGradient")({
+                Name: "ExperienceGradient",
+                Color: new ColorSequence([
+                        new ColorSequenceKeypoint(0, Color3.fromRGB(94, 0, 255)),
+                        new ColorSequenceKeypoint(0.5, Color3.fromRGB(170, 0, 255)),
+                        new ColorSequenceKeypoint(1, Color3.fromRGB(255, 128, 255)),
+                ]),
+                Transparency: new NumberSequence(0),
+                Rotation: 90,
+        });


### PR DESCRIPTION
## Summary
- create ExperienceBar and LevelGem molecules
- add ProgressionCard organism
- extend ProgressionSlice with next-level tracking
- add new ExperienceGradient asset
- document new modules in AGENTS_DEVELOPMENT_SUMMARY

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c00da7114832785884d2752b0d6f4