### PR TITLE
Fix ExperiencePercent initialization

### DIFF
--- a/src/client/states/ProgressionSlice.ts
+++ b/src/client/states/ProgressionSlice.ts
@@ -20,18 +20,20 @@ import { ServerDispatch } from "shared/network/Definitions";
 export default class ProgressionSlice {
 	private static instance: ProgressionSlice;
 
-	public readonly Progression: Record<ProgressionKey, Value<number>> = {} as never;
-	public readonly NextLevelExperience = Value(DefaultProgression.NextLevelExperience);
-	public readonly ExperiencePercent = Computed(
-		() => this.Progression.Experience.get() / math.max(this.NextLevelExperience.get(), 1),
-	);
+        public readonly Progression: Record<ProgressionKey, Value<number>> = {} as never;
+        public readonly NextLevelExperience = Value(DefaultProgression.NextLevelExperience);
+        public readonly ExperiencePercent!: Computed<number>;
 
 	private constructor() {
-		for (const key of PROGRESSION_KEYS) {
-			this.Progression[key] = Value(DefaultProgression[key]);
-		}
-		this.fetchFromServer();
-		this.setupListeners();
+                for (const key of PROGRESSION_KEYS) {
+                        this.Progression[key] = Value(DefaultProgression[key]);
+                }
+                this.ExperiencePercent = Computed(() =>
+                        this.Progression.Experience.get() /
+                        math.max(this.NextLevelExperience.get(), 1),
+                );
+                this.fetchFromServer();
+                this.setupListeners();
 	}
 
 	private async fetchFromServer() {


### PR DESCRIPTION
## Summary
- prevent `ProgressionSlice` from reading uninitialized Values when computing `ExperiencePercent`

## Testing
- `npm test` *(fails: rbxtsc not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686c1fb4537883279c2d40d8ea66206f