### PR TITLE
Add user message UI

### DIFF
--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -32,6 +32,7 @@ The table below lists core modules grouped by network layer and their current st
 |Client|`client/ui/molecules/SettingListItem.ts`|Usable|Displays and edits a single setting|
 |Client|`client/ui/molecules/ExperienceBar.ts`|Usable|Displays experience progress|
 |Client|`client/ui/molecules/LevelGem.ts`|Usable|Shows current level|
+|Client|`client/ui/molecules/UserMessage.ts`|Usable|Center-screen popup messages|
 |Client|`client/states/SettingsState.ts`|Usable|Reactive settings container|
 |Client|`client/network/ClientNetworkService.ts`|Usable|Client RPC helpers|
 |Client|`client/network/listener.client.ts`|Usable|Receives server events|
@@ -50,6 +51,7 @@ The table below lists core modules grouped by network layer and their current st
 |Client|`client/states/AttributesSlice.ts`|Under Construction|Attribute values and points|
 |Client|`client/states/ResourceSlice.ts`|Under Construction|Player resource values|
 |Client|`client/states/ProgressionSlice.ts`|Usable|Level and experience slice|
+|Client|`client/states/MessageSlice.ts`|Usable|Transient user messages|
 |Client|`client/states/CurrencySlice.ts`|Stub|Currency amounts|
 |Server|`server/main.server.ts`|Under Construction|Joins players and loads profiles|
 |Server|`server/network/listener.server.ts`|Usable|Server network handlers|

--- a/src/client/states/MessageSlice.ts
+++ b/src/client/states/MessageSlice.ts
@@ -1,0 +1,51 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        MessageSlice.ts
+ * @module      MessageSlice
+ * @layer       Client/State
+ * @description Reactive container for transient user messages.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Codex
+ * @license      MIT
+ * @since        0.2.1
+ * @lastUpdated  2025-07-06 by Codex – Initial creation
+ *
+ * @dependencies
+ *   @rbxts/fusion ^0.4.0
+ */
+
+import Fusion from "@rbxts/fusion";
+
+const { Value } = Fusion;
+
+export default class MessageSlice {
+        private static instance: MessageSlice;
+
+        public readonly Text = Value("");
+        public readonly Visible = Value(false);
+        public readonly IsError = Value(false);
+
+        private constructor() {}
+
+        public show(text: string, isError = false, duration = 2) {
+                this.Text.set(text);
+                this.IsError.set(isError);
+                this.Visible.set(true);
+                task.delay(duration, () => {
+                        this.Visible.set(false);
+                });
+        }
+
+        public static getInstance(): MessageSlice {
+                if (!this.instance) {
+                        this.instance = new MessageSlice();
+                }
+                return this.instance;
+        }
+}

--- a/src/client/states/index.ts
+++ b/src/client/states/index.ts
@@ -16,3 +16,4 @@ export { default as ResourceSlice } from "./ResourceSlice";
 export { default as AttributesSlice } from "./AttributesSlice";
 export { default as ProgressionSlice } from "./ProgressionSlice";
 export { default as CurrencySlice } from "./CurrencySlice";
+export { default as MessageSlice } from "./MessageSlice";

--- a/src/client/ui/molecules/UserMessage.ts
+++ b/src/client/ui/molecules/UserMessage.ts
@@ -1,0 +1,79 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        UserMessage.ts
+ * @module      UserMessage
+ * @layer       Client/UI/Molecules
+ * @description Center-screen popup for transient user messages.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Codex
+ * @license      MIT
+ * @since        0.2.1
+ * @lastUpdated  2025-07-06 by Codex – Initial creation
+ *
+ * @dependencies
+ *   @rbxts/fusion ^0.4.0
+ */
+
+import Fusion, { New, Children, Observer, Computed } from "@rbxts/fusion";
+import { Players, TweenService } from "@rbxts/services";
+import { useToken } from "theme/hooks";
+import MessageSlice from "client/states/MessageSlice";
+
+const slice = MessageSlice.getInstance();
+
+export function UserMessage() {
+        const textColor = useToken("textPrimary");
+
+        let label: TextLabel | undefined;
+
+        Observer(slice.Visible).onChange(() => {
+                if (label) {
+                        label.Visible = slice.Visible.get();
+                        if (slice.Visible.get()) {
+                                label.Size = UDim2.fromScale(0, 0);
+                                label.Position = UDim2.fromScale(0.5, 0.5);
+                                TweenService.Create(
+                                        label,
+                                        new TweenInfo(0.3, Enum.EasingStyle.Back, Enum.EasingDirection.Out),
+                                        { Size: UDim2.fromScale(0.6, 0.1) },
+                                ).Play();
+                                if (slice.IsError.get()) {
+                                TweenService.Create(
+                                        label,
+                                        new TweenInfo(0.1, Enum.EasingStyle.Linear, Enum.EasingDirection.InOut, 5, true),
+                                        { Position: new UDim2(0.5, 5, 0.5, 0) },
+                                ).Play();
+                                }
+                        }
+                }
+        });
+
+        const colour = Computed(() => (slice.IsError.get() ? Color3.fromRGB(255, 80, 80) : textColor.get()));
+
+        label = New("TextLabel")({
+                Name: "MessageLabel",
+                AnchorPoint: new Vector2(0.5, 0.5),
+                Position: UDim2.fromScale(0.5, 0.5),
+                Size: UDim2.fromScale(0, 0),
+                BackgroundTransparency: 0.4,
+                BackgroundColor3: Color3.fromRGB(0, 0, 0),
+                TextColor3: colour,
+                TextScaled: true,
+                Font: Enum.Font.SourceSansBold,
+                Text: slice.Text,
+                Visible: slice.Visible,
+        });
+
+        return New("ScreenGui")({
+                Name: "UserMessage",
+                Parent: Players.LocalPlayer.WaitForChild("PlayerGui"),
+                ResetOnSpawn: false,
+                [Children]: { Message: label },
+        });
+}

--- a/src/client/ui/molecules/index.ts
+++ b/src/client/ui/molecules/index.ts
@@ -18,3 +18,4 @@ export * from "./GameWindow";
 export * from "./SettingListItem";
 export * from "./ExperienceBar";
 export * from "./LevelGem";
+export * from "./UserMessage";


### PR DESCRIPTION
## Summary
- add `MessageSlice` to manage transient user messages
- create `UserMessage` molecule component to display center-screen popup
- update barrels and development summary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c24bfa7d883279262356cb1cfd3cd