### PR TITLE
Enhance theme tokens

### DIFF
--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -16,7 +16,7 @@ The table below lists core modules grouped by network layer and their current st
 |Shared|`shared/data/RigData.ts`|Usable|Rig template references|
 |Shared|`shared/assets`|Usable|Image asset constants|
 |Shared|`shared/states`|Usable|Signal-based shared state|
-|Shared|`theme`|Usable|Fusion theme store|
+|Shared|`theme`|Usable|Fusion theme store with Fateless theme|
 |Shared|`constants`|Rock Solid|Sizes and asset ids|
 |Client|`client/main.client.ts`|Usable|Entry point and UI bootstrap|
 |Client|`client/stylesheet.client.ts`|Under Construction|StyleSheet prototype|

--- a/src/client/states/ThemeState.ts
+++ b/src/client/states/ThemeState.ts
@@ -16,6 +16,7 @@ import Fusion from "@rbxts/fusion";
 import { ThemeKey, DEFAULT_THEME } from "../../theme/ThemeKey";
 import { cyberGothic } from "../../theme/tokens/cyberGothic";
 import { solarDrift } from "../../theme/tokens/solarDrift";
+import { fateless } from "../../theme/tokens/fateless";
 import { ThemeTokens } from "../../theme/types";
 
 const { Value, Computed } = Fusion;
@@ -23,8 +24,9 @@ const { Value, Computed } = Fusion;
 const themeKey = Value<ThemeKey>(DEFAULT_THEME);
 
 const themeMap: Record<ThemeKey, ThemeTokens> = {
-	[ThemeKey.CyberGothic]: cyberGothic,
-	[ThemeKey.SolarDrift]: solarDrift,
+        [ThemeKey.CyberGothic]: cyberGothic,
+        [ThemeKey.SolarDrift]: solarDrift,
+        [ThemeKey.Fateless]: fateless,
 };
 
 const currentTokens = Computed(() => themeMap[themeKey.get()]);

--- a/src/theme/ThemeKey.ts
+++ b/src/theme/ThemeKey.ts
@@ -15,8 +15,9 @@
 /* =============================================== Theme Enumeration ======================= */
 
 export enum ThemeKey {
-	CyberGothic = "CyberGothic",
-	SolarDrift = "SolarDrift",
+        CyberGothic = "CyberGothic",
+        SolarDrift = "SolarDrift",
+        Fateless = "Fateless",
 }
 
 export const DEFAULT_THEME = ThemeKey.SolarDrift;

--- a/src/theme/tokens/cyberGothic.ts
+++ b/src/theme/tokens/cyberGothic.ts
@@ -18,12 +18,17 @@ import { Sizes } from "../../constants/Sizes";
 /* =============================================== Token Table ============================= */
 
 export const cyberGothic: ThemeTokens = {
-	colours: {
-		panelBg: Color3.fromRGB(16, 16, 16),
-		panelBorder: Color3.fromRGB(0, 255, 153),
-		textPrimary: Color3.fromRGB(0, 255, 153),
-		textSecondary: Color3.fromRGB(179, 255, 230),
-	},
+        colours: {
+                panelBg: Color3.fromRGB(16, 16, 16),
+                panelBgHover: Color3.fromRGB(32, 32, 32),
+                panelBorder: Color3.fromRGB(0, 255, 153),
+                textPrimary: Color3.fromRGB(0, 255, 153),
+                textSecondary: Color3.fromRGB(179, 255, 230),
+                textDisabled: Color3.fromRGB(100, 100, 100),
+                healthFill: Color3.fromRGB(255, 64, 128),
+                manaFill: Color3.fromRGB(0, 200, 255),
+                staminaFill: Color3.fromRGB(128, 255, 0),
+        },
 	fonts: {
 		family: Enum.Font.Arcade,
 		weightNormal: 400,

--- a/src/theme/tokens/fateless.ts
+++ b/src/theme/tokens/fateless.ts
@@ -1,0 +1,39 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        fateless.ts
+ * @module      FatelessTokens
+ * @layer       Shared
+ * @description Token table for the imaginative Fateless theme.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ */
+
+import { ThemeTokens } from "../types";
+
+/* =============================================== Token Table ============================= */
+
+export const fateless: ThemeTokens = {
+        colours: {
+                panelBg: Color3.fromRGB(5, 5, 15),
+                panelBgHover: Color3.fromRGB(20, 20, 40),
+                panelBorder: Color3.fromRGB(100, 0, 255),
+                textPrimary: Color3.fromRGB(230, 230, 255),
+                textSecondary: Color3.fromRGB(150, 150, 200),
+                textDisabled: Color3.fromRGB(80, 80, 90),
+                healthFill: Color3.fromRGB(255, 80, 105),
+                manaFill: Color3.fromRGB(105, 80, 255),
+                staminaFill: Color3.fromRGB(80, 255, 160),
+        },
+        fonts: {
+                family: Enum.Font.Gotham,
+                weightNormal: 400,
+                weightBold: 700,
+        },
+        images: {
+                panelBorderSlice: "rbxassetid://1122334455",
+        },
+};

--- a/src/theme/tokens/index.ts
+++ b/src/theme/tokens/index.ts
@@ -1,3 +1,4 @@
 export * from "./base";
 export * from "./cyberGothic";
 export * from "./solarDrift";
+export * from "./fateless";

--- a/src/theme/tokens/solarDrift.ts
+++ b/src/theme/tokens/solarDrift.ts
@@ -17,12 +17,17 @@ import { ThemeTokens } from "../types";
 /* =============================================== Token Table ============================= */
 
 export const solarDrift: ThemeTokens = {
-	colours: {
-		panelBg: Color3.fromRGB(41, 13, 13),
-		panelBorder: Color3.fromRGB(255, 175, 0),
-		textPrimary: Color3.fromRGB(252, 222, 158),
-		textSecondary: Color3.fromRGB(99, 99, 99),
-	},
+        colours: {
+                panelBg: Color3.fromRGB(41, 13, 13),
+                panelBgHover: Color3.fromRGB(61, 23, 23),
+                panelBorder: Color3.fromRGB(255, 175, 0),
+                textPrimary: Color3.fromRGB(252, 222, 158),
+                textSecondary: Color3.fromRGB(99, 99, 99),
+                textDisabled: Color3.fromRGB(70, 70, 70),
+                healthFill: Color3.fromRGB(255, 80, 80),
+                manaFill: Color3.fromRGB(80, 180, 255),
+                staminaFill: Color3.fromRGB(255, 210, 80),
+        },
 	fonts: {
 		family: Enum.Font.SciFi,
 		weightNormal: 400,

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -15,10 +15,15 @@
 /* =============================================== Token Groups ============================ */
 
 export interface ColourTokens {
-	panelBg: Color3;
-	panelBorder: Color3;
-	textPrimary: Color3;
-	textSecondary: Color3;
+        panelBg: Color3;
+        panelBgHover: Color3;
+        panelBorder: Color3;
+        textPrimary: Color3;
+        textSecondary: Color3;
+        textDisabled: Color3;
+        healthFill: Color3;
+        manaFill: Color3;
+        staminaFill: Color3;
 }
 
 export interface FontTokens {


### PR DESCRIPTION
## Summary
- extend theme token types to support more colour options
- flesh out CyberGothic and SolarDrift tokens
- add Fateless theme
- register Fateless in theme state
- update development summary

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c3c6747708327ae18843f5e7a355a