### PR TITLE
Fix outdated network references in docs

### DIFF
--- a/Maintenance_Comment_Review_List.md
+++ b/Maintenance_Comment_Review_List.md
@@ -7,9 +7,9 @@ This checklist tracks comment updates for each file.
 - [x] **[scripts/task-cli.ts](./scripts/task-cli.ts)**
 - [x] **[src/client/index.ts](./src/client/index.ts)**
 - [x] **[src/client/main.client.ts](./src/client/main.client.ts)**
-- [x] **[src/client/network/ClientNetworkService.ts](./src/client/network/ClientNetworkService.ts)**
+- [x] **[src/client/network/ClientNetwork.ts](./src/client/network/ClientNetwork.ts)**
 - [x] **[src/client/network/index.ts](./src/client/network/index.ts)**
-- [x] **[src/client/network/listener.client.ts](./src/client/network/listener.client.ts)**
+- [x] **[src/client/network/network.client.ts](./src/client/network/network.client.ts)**
 - [x] **[src/client/states/PlayerState.ts](./src/client/states/PlayerState.ts)**
 - [x] **[src/client/states/ScreenState.ts](./src/client/states/ScreenState.ts)**
 - [x] **[src/client/states/SettingsState.ts](./src/client/states/SettingsState.ts)**

--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -35,8 +35,8 @@ The table below lists core modules grouped by network layer and their current st
 |Client|`client/ui/molecules/LevelGem.ts`|Usable|Shows current level|
 |Client|`client/ui/molecules/UserMessage.ts`|Usable|Center-screen popup messages|
 |Client|`client/states/SettingsState.ts`|Usable|Reactive settings container|
-|Client|`client/network/ClientNetworkService.ts`|Usable|Client RPC helpers|
-|Client|`client/network/listener.client.ts`|Usable|Receives server events|
+|Client|`client/network/ClientNetwork.ts`|Usable|Client RPC helpers|
+|Client|`client/network/network.client.ts`|Usable|Receives server events|
 |Client|`client/ui/screens`|Under Construction|Gem forge, character, inventory, shop, settings, teleport and HUD screens|
 |Client|`client/ui/screens/DragDropScreen.ts`|Usable|Drag and drop demo|
 |Client|`client/ui/screens/CharacterScreen.ts`|Stub|Character info window|


### PR DESCRIPTION
## Summary
- update network paths in `AGENTS_DEVELOPMENT_SUMMARY.md`
- update network paths in `Maintenance_Comment_Review_List.md`

## Testing
- `node codexUtility/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_686cf603e3588327bf9b1db885383574