### PR TITLE
Fix resource percent reactivity

### DIFF
--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -13,6 +13,7 @@ The table below lists core modules grouped by network layer and their current st
 |Shared|`shared/data/PlayerData.ts`|Stub|Player profile template|
 |Shared|`shared/data/RarityData.ts`|Rock Solid|Rarity metadata|
 |Shared|`shared/data/ResourceData.ts`|Rock Solid|Resource metadata|
+|Shared|`shared/definitions/Resources.ts`|Usable|Resource state helpers|
 |Shared|`shared/data/RigData.ts`|Usable|Rig template references|
 |Shared|`shared/assets`|Usable|Image asset constants|
 |Shared|`shared/states`|Usable|Signal-based shared state|

--- a/src/shared/definitions/Resources.ts
+++ b/src/shared/definitions/Resources.ts
@@ -81,17 +81,23 @@ export type ResourceStateMap = {
 };
 
 export function createResourceState(key: ResourceKey, initialData?: ResourceDTO) {
-	const data = initialData || { current: 0, max: 100 };
-	return {
-		current: Value(data.current),
-		max: Value(data.max),
-		regenPerSecond: data.regenPerSecond !== undefined ? Value(data.regenPerSecond) : undefined,
-		percent: Computed(() => {
-			const current = data.current;
-			const max = data.max;
-			return max > 0 ? current / max : 0;
-		}),
-	};
+        const data = initialData || { current: 0, max: 100 };
+
+        const currentValue = Value(data.current);
+        const maxValue = Value(data.max);
+        const regenValue =
+                data.regenPerSecond !== undefined ? Value(data.regenPerSecond) : undefined;
+
+        return {
+                current: currentValue,
+                max: maxValue,
+                regenPerSecond: regenValue,
+                percent: Computed(() => {
+                        const current = currentValue.get();
+                        const max = maxValue.get();
+                        return max > 0 ? current / max : 0;
+                }),
+        };
 }
 
 export function createStateResources(initialData?: ResourceDataMap) {


### PR DESCRIPTION
## Summary
- fix `createResourceState` percent computed to read from Values
- track resource state helpers in development summary

## Testing
- `node codexUtility/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_686cf5fdda0083279fbe497c4df3d7a4