### PR TITLE
Add Nx generator script template

### DIFF
--- a/tools/project.json
+++ b/tools/project.json
@@ -11,9 +11,27 @@
       "options": {
         "command": "rbxtsc --project tsconfig.json"
       },
-      "outputs": ["out/**"]
+      "outputs": [
+        "out/**"
+      ]
     },
-    "lint":  { "executor": "nx:run-commands", "options": { "command": "biome lint ." } },
-"format":{ "executor": "nx:run-commands", "options": { "command": "biome format --write ." } }
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "biome lint ."
+      }
+    },
+    "format": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "biome format --write ."
+      }
+    },
+    "generate-script": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "node tools/script-template.js"
+      }
+    }
   }
 }

--- a/tools/script-template.js
+++ b/tools/script-template.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+/**
+ * @file script-template.js
+ * @module ScriptTemplate
+ * @description Generates a small example script to verify the Nx toolchain.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Tools           │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Codex
+ * @license      MIT
+ * @since        0.1.0
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const outputPath = path.join(__dirname, 'generated-script.js');
+const content = `#!/usr/bin/env node\nconsole.log('Generated script executed successfully.');\n`;
+
+fs.writeFileSync(outputPath, content, 'utf8');
+console.log(`Generated ${outputPath}`);
+


### PR DESCRIPTION
## Summary
- add a template Node script under tools to generate a simple script
- register a `generate-script` target in `tools/project.json`

## Testing
- `node tools/script-template.js`


------
https://chatgpt.com/codex/tasks/task_e_686d0d1ae970832797343a5f9309116d