### PR TITLE
Add Nx Agents guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,8 @@ import Fusion from "@rbxts/fusion";
 5. [AGENTS_TASK_TEMPLATE.md](./src/AGENTS_TASK_TEMPLATE.md) – for creating new tasks and components.
 6. [Tasks Folder](./tasks) – for storing tasks and components created by agents. and using the new task system.
 
+7. [Nx Agents Guide](./Documents/NxAgentsGuide.md) – how to run Nx targets and maintain the toolchain.
+
 ## 7 CodexUtility Section
 
 A workspace-level folder named `codexUtility` houses automation scripts and utilities that operate on both the TypeScript source (`src/`) and the compiled Lua output (`out/`), as well as project configuration and packaging files.

--- a/Documents/NxAgentsGuide.md
+++ b/Documents/NxAgentsGuide.md
@@ -1,0 +1,45 @@
+# Nx Agents Guide
+
+This document outlines how Codex should interact with the Nx toolchain for the **Soul Steel** project.
+It complements `AGENTS.md` with build and automation details.
+
+## 1 • Directory Overview
+
+```
+src/                # game source split by client/server/shared
+  client/
+  server/
+  shared/
+
+tools/              # Nx project with command targets
+```
+
+The Nx tasks are defined in `tools/project.json` and `tools/game.json`. Each target
+executes a command via `nx:run-commands`.
+
+## 2 • Common Nx Commands
+
+| Purpose        | Command                         | Notes                       |
+| -------------- | ------------------------------- | --------------------------- |
+| Build game     | `nx run tools:game`            | Compiles TS to `out/`       |
+| Lint files     | `nx run tools:lint`            | Uses Biome                  |
+| Format files   | `nx run tools:format`          | Writes formatted files      |
+| Hello example  | `nx run tools:hello`           | Prints a greeting           |
+| Generate script| `nx run tools:generate-script` | Creates `generated-script.js` in `tools/`
+
+Run commands with `npx` if Nx is not installed globally:
+
+```bash
+npx nx run tools:game
+```
+
+## 3 • Caching & Tips
+
+* Nx stores build cache in `.nx/cache`. Repeated commands are faster.
+* Tasks output to `out/` or `tools/` as listed in each target.
+* Keep `tools/project.json` updated when adding new scripts.
+
+## 4 • Maintenance
+
+Update this guide when Nx targets or directory layout changes so Codex always runs the correct commands.
+


### PR DESCRIPTION
## Summary
- document how Codex should run Nx commands
- reference the new Nx guide from AGENTS.md

## Testing
- `npx nx run tools:lint` *(fails: No existing Nx Cloud client and failed to download new version)*

------
https://chatgpt.com/codex/tasks/task_e_686d1194143083279774d301de0597da