### PR TITLE
Deprecate GamePanel for updated containers

### DIFF
--- a/Documents/OrganismStructure.md
+++ b/Documents/OrganismStructure.md
@@ -35,7 +35,7 @@ management. To maintain clarity and consistency, we recommend the following stru
 
 // -------------- Imports ----------------------------------------------------- //
 import Fusion, { New } from "@rbxts/fusion";
-import { GamePanel, GameButton } from "client/atoms";        // absolute alias
+import { BaseContainer, ListContainer, GameButton } from "client/atoms";        // absolute alias
 import { BarMeter } from "client/molecules";
 import { PlayerHealth, PlayerMana, PlayerStamina } from "shared/states/PlayerState";
 import { Layout, Padding } from "client/style";
@@ -72,12 +72,13 @@ const DEBUG = {
  */
 export const ResourceBars = (debug = false) => {
  /* ---------- Dev-only controls ----------------------------------------- */
- const DebugPanel = debug
-  ? GamePanel({
+const DebugPanel = debug
+  ? ListContainer({
     Name: "ResourceBarsDebug",
     Size: DEBUG.CONTAINER_SIZE,
     Position: UDim2.fromScale(0, 1),
-    Layout: Layout.HorizontalSet(5),
+    LayoutOrientation: "horizontal",
+    Gap: 5,
     Padding: Padding(2),
     Children: {
      HealthDown:   makeDrainButton(GameImages.Attributes.Vitality,  PlayerHealth.Current),
@@ -88,9 +89,10 @@ export const ResourceBars = (debug = false) => {
   : undefined; // ← Nothing is created if debug === false
 
  /* ---------- Resource bar stack ---------------------------------------- */
- const Bars = GamePanel({
+const Bars = ListContainer({
   Name: "ResourceBarsStack",
-  Layout: Layout.VerticalSet(5),
+  LayoutOrientation: "vertical",
+  Gap: 5,
   Children: {
    Health:  makeBar(PlayerHealth,  COLORS.HEALTH),
    Mana:    makeBar(PlayerMana,    COLORS.MANA),
@@ -99,7 +101,7 @@ export const ResourceBars = (debug = false) => {
  });
 
  /* ---------- Final organism root --------------------------------------- */
- return GamePanel({
+ return BaseContainer({
   Name: "ResourceBarsOrganism",
   Size: ORG.SIZE,
   Position: ORG.POSITION,

--- a/Maintenance_Comment_Review_List.md
+++ b/Maintenance_Comment_Review_List.md
@@ -23,7 +23,7 @@ This checklist tracks comment updates for each file.
 - [x] **[src/client/ui/atoms/Button/UIButton.ts](./src/client/ui/atoms/Button/UIButton.ts)**
 - [x] **[src/client/ui/atoms/Button/index.ts](./src/client/ui/atoms/Button/index.ts)**
 - [x] **[src/client/ui/atoms/Container/BaseContainer.ts](./src/client/ui/atoms/Container/BaseContainer.ts)**
-- [x] **[src/client/ui/atoms/Container/GamePanel.ts](./src/client/ui/atoms/Container/GamePanel.ts)**
+- [x] ~~**[src/client/ui/atoms/Container/GamePanel.ts](./src/client/ui/atoms/Container/GamePanel.ts)**~~ (deprecated)
 - [x] **[src/client/ui/atoms/Container/GridContainer.ts](./src/client/ui/atoms/Container/GridContainer.ts)**
 - [x] **[src/client/ui/atoms/Container/HorizontalContainer.ts](./src/client/ui/atoms/Container/HorizontalContainer.ts)**
 - [x] **[src/client/ui/atoms/Container/VerticalContainer.ts](./src/client/ui/atoms/Container/VerticalContainer.ts)**

--- a/src/client/ui/atoms/Container/GamePanel.ts
+++ b/src/client/ui/atoms/Container/GamePanel.ts
@@ -19,6 +19,7 @@
  * @dependencies
  *   @rbxts/fusion ^0.4.0
  *
+ * @deprecated Use BaseContainer or ListContainer instead.
  */
 
 import Fusion, { New, Children, Computed, Value, OnEvent, PropertyTable } from "@rbxts/fusion";

--- a/src/client/ui/atoms/Container/ListContainer.ts
+++ b/src/client/ui/atoms/Container/ListContainer.ts
@@ -13,16 +13,19 @@
  */
 
 import Fusion, { Children } from "@rbxts/fusion";
+import { useToken } from "theme/hooks";
 
 export interface ListContainerProps extends Partial<Fusion.PropertyTable<Frame>> {
-	Gap?: number;
-	LayoutOrientation: "vertical" | "horizontal";
-	Content?: Fusion.ChildrenValue;
-	AlignmentType?: Enum.HorizontalAlignment | Enum.VerticalAlignment;
+        Gap?: number;
+        LayoutOrientation: "vertical" | "horizontal";
+        Content?: Fusion.ChildrenValue;
+        AlignmentType?: Enum.HorizontalAlignment | Enum.VerticalAlignment;
+       Padding?: UIPadding;
 }
 
 export const ListContainer = (props: ListContainerProps) => {
-	const uiListLayout = Fusion.New("UIListLayout")({
+       const bg = useToken("panelBg");
+       const uiListLayout = Fusion.New("UIListLayout")({
 		SortOrder: Enum.SortOrder.LayoutOrder,
 		FillDirection:
 			props.LayoutOrientation === "horizontal" ? Enum.FillDirection.Horizontal : Enum.FillDirection.Vertical,
@@ -41,12 +44,14 @@ export const ListContainer = (props: ListContainerProps) => {
 		Name: "ListContainer",
 		Size: props.Size ?? UDim2.fromScale(1, 1),
 		Position: props.Position ?? UDim2.fromScale(0, 0),
-		BackgroundTransparency: props.BackgroundTransparency ?? 1,
+               BackgroundColor3: props.BackgroundColor3 ?? bg,
+               BackgroundTransparency: props.BackgroundTransparency ?? 1,
 		AnchorPoint: props.AnchorPoint ?? new Vector2(0, 0),
-		[Children]: {
-			Layout: uiListLayout,
-			...props.Content,
-		},
+               [Children]: {
+                       Layout: uiListLayout,
+                       Padding: props.Padding,
+                       ...props.Content,
+               },
 	});
 
 	return Component;

--- a/src/client/ui/atoms/Container/index.ts
+++ b/src/client/ui/atoms/Container/index.ts
@@ -9,4 +9,3 @@
 
 export * from "../BaseContainer";
 export * from "./ListContainer";
-export * from "./GamePanel";

--- a/src/client/ui/atoms/UIButton.ts
+++ b/src/client/ui/atoms/UIButton.ts
@@ -14,7 +14,7 @@
 
 // -------------- Imports ------------- //
 import Fusion, { Children, Computed, New, OnEvent, PropertyTable, Value } from "@rbxts/fusion";
-import { BaseContainer, GamePanel } from "./Container";
+import { BaseContainer } from "./Container";
 import { GameText } from "./GameText";
 import { BorderImage } from "./BorderImage";
 import { GameImages } from "shared/assets";

--- a/src/client/ui/molecules/AbilityInfoPanel.ts
+++ b/src/client/ui/molecules/AbilityInfoPanel.ts
@@ -1,7 +1,6 @@
 import { AbilitiesMeta, AbilityKey } from "shared/definitions/ProfileDefinitions/Ability";
-import { GamePanel, GameImage, GameText } from "../atoms";
+import { BaseContainer, ListContainer, GameImage, GameText } from "../atoms";
 import { New, Value } from "@rbxts/fusion";
-import { Layout } from "../tokens";
 
 export interface AbilityInfoPanelProps {
 	abilityKey: AbilityKey;
@@ -42,25 +41,28 @@ export function AbilityInfoPanel({ abilityKey }: AbilityInfoPanelProps) {
 		Size: UDim2.fromScale(1, 0.3),
 	});
 
-	return GamePanel({
-		Name: `AbilityInfoPanel-${abilityKey}`,
-		Size: UDim2.fromOffset(300, 200),
-		Layout: Layout.VerticalSet(2),
+       return ListContainer({
+               Name: `AbilityInfoPanel-${abilityKey}`,
+               Size: UDim2.fromOffset(300, 200),
+               LayoutOrientation: "vertical",
+               Gap: 2,
 
 		Content: {
-			TopRow: GamePanel({
-				Name: `TopRow-${abilityKey}`,
-				Layout: Layout.HorizontalSet(2),
-				Size: UDim2.fromScale(1, 0.3),
+                       TopRow: ListContainer({
+                               Name: `TopRow-${abilityKey}`,
+                               LayoutOrientation: "horizontal",
+                               Gap: 2,
+                               Size: UDim2.fromScale(1, 0.3),
 				Content: {
 					AbilityIcon: abilityIcon,
 					AbilityName: abilityName,
 				},
 			}),
-			BottomRow: GamePanel({
-				Name: `BottomRow-${abilityKey}`,
-				Layout: Layout.VerticalSet(2),
-				Size: UDim2.fromScale(1, 0.7),
+                       BottomRow: ListContainer({
+                               Name: `BottomRow-${abilityKey}`,
+                               LayoutOrientation: "vertical",
+                               Gap: 2,
+                               Size: UDim2.fromScale(1, 0.7),
 				Content: {
 					AbilityDescription: abilityDescription,
 					AbilityCooldown: abilityCooldown,

--- a/src/client/ui/molecules/AvatarBust.ts
+++ b/src/client/ui/molecules/AvatarBust.ts
@@ -1,6 +1,6 @@
 import { Players } from "@rbxts/services";
 import { New, Value } from "@rbxts/fusion";
-import { BorderImage, GamePanel } from "../atoms";
+import { BorderImage, BaseContainer } from "../atoms";
 
 export const AvatarBust = (userId: number, layoutOrder?: number) => {
 	const avatarImage = New("ImageLabel")({
@@ -15,10 +15,10 @@ export const AvatarBust = (userId: number, layoutOrder?: number) => {
 		)[0] as string, // Get the first image URL
 	});
 
-	return GamePanel({
-		Name: "AvatarBust",
-		Size: new UDim2(0, 100, 0, 100),
-		BackgroundTransparency: 1,
+       return BaseContainer({
+               Name: "AvatarBust",
+               Size: new UDim2(0, 100, 0, 100),
+               BackgroundTransparency: 1,
 		BorderImage: BorderImage.GothicMetal(),
 		Content: {
 			Image: avatarImage,

--- a/src/client/ui/molecules/FillBar/BarMeter.ts
+++ b/src/client/ui/molecules/FillBar/BarMeter.ts
@@ -21,7 +21,7 @@
  */
 
 import Fusion, { Children, New, Value, Computed } from "@rbxts/fusion";
-import { BorderImage, GamePanel, GameText } from "../../atoms";
+import { BorderImage, BaseContainer, GameText } from "../../atoms";
 import { ComponentSizes } from "constants";
 
 export interface BarMeterProps extends Fusion.PropertyTable<Frame> {
@@ -60,9 +60,9 @@ export function BarMeter(props: BarMeterProps) {
 	});
 
 	/* Container */
-	const container = GamePanel({
-		Name: "BarMeter",
-		Size: props.Size ?? ComponentSizes.ResourceBar,
+       const container = BaseContainer({
+               Name: "BarMeter",
+               Size: props.Size ?? ComponentSizes.ResourceBar,
 		AnchorPoint: props.AnchorPoint ?? new Vector2(0.5, 0.5),
 		Position: props.Position ?? new UDim2(0.5, 0, 0.5, 0),
 		BorderImage: BorderImage.GothicMetal(),

--- a/src/client/ui/molecules/GameWindow.ts
+++ b/src/client/ui/molecules/GameWindow.ts
@@ -21,7 +21,7 @@
  */
 
 import Fusion, { Children, New, OnEvent } from "@rbxts/fusion";
-import { BaseContainer, GamePanel } from "../atoms";
+import { BaseContainer } from "../atoms";
 import { Players } from "@rbxts/services";
 import { GameImages } from "shared/assets";
 import { ScreenKey, ScreenState } from "client/states";

--- a/src/client/ui/molecules/LevelGem.ts
+++ b/src/client/ui/molecules/LevelGem.ts
@@ -7,7 +7,7 @@
  * @description Displays the player's current level as a gem icon.
  */
 
-import { GameImage, GamePanel, GameText } from "../atoms";
+import { GameImage, BaseContainer, GameText } from "../atoms";
 import { GameImages } from "shared/assets";
 import { Value, Observer } from "@rbxts/fusion";
 import ProgressionSlice from "client/states/ProgressionSlice";
@@ -19,8 +19,8 @@ export function LevelGem() {
 		labelValue.set(`Lv ${level.get()}`);
 	});
 
-	return GamePanel({
-		Name: "LevelGem",
+       return BaseContainer({
+               Name: "LevelGem",
 		Size: new UDim2(0, 60, 0, 60),
 		BackgroundTransparency: 1,
 		Content: {

--- a/src/client/ui/organisms/ButtonBars/AbilityBar.ts
+++ b/src/client/ui/organisms/ButtonBars/AbilityBar.ts
@@ -19,7 +19,7 @@
  *  The buttons are dynamically generated based on the abilities available to the player.
  *  The component uses Fusion for reactive UI updates and layout management.
  *  It is designed to be flexible and easily extendable for future abilities.
- *  The component is styled using the GamePanel atom for consistent UI appearance.
+ *  The component is styled using the ListContainer atom for consistent UI appearance.
  *  The buttons are arranged horizontally with a set layout and spacing.
  *  The component is intended to be used within the player HUD screen, providing quick access to
  *  abilities during gameplay.

--- a/src/client/ui/organisms/CharacterInfoCard.ts
+++ b/src/client/ui/organisms/CharacterInfoCard.ts
@@ -1,6 +1,5 @@
-import { BorderImage, GamePanel } from "../atoms";
+import { BorderImage, ListContainer, BaseContainer } from "../atoms";
 import { ResourceBar } from "./ResourceBar";
-import { Layout } from "../tokens";
 import { Players } from "@rbxts/services";
 import { AvatarBust } from "../molecules/AvatarBust";
 
@@ -10,33 +9,33 @@ export const CharacterInfoCard = (layoutOrder?: number) => {
 	const AvatarWidth = Avatar.Size.X.Offset;
 
 	/* Resource Bars */
-	const ResourceBarContainer = GamePanel({
-		Name: "ResourceBars",
-		Size: new UDim2(1, -AvatarWidth, 1, 0),
-		Layout: Layout.VerticalSet(),
-		LayoutOrder: 2,
-		Content: {
-			HealthBar: ResourceBar("Health"),
-			ManaBar: ResourceBar("Mana"),
-			StaminaBar: ResourceBar("Stamina"),
-		},
+       const ResourceBarContainer = ListContainer({
+               Name: "ResourceBars",
+               Size: new UDim2(1, -AvatarWidth, 1, 0),
+               LayoutOrientation: "vertical",
+               LayoutOrder: 2,
+               Content: {
+                       HealthBar: ResourceBar("Health"),
+                       ManaBar: ResourceBar("Mana"),
+                       StaminaBar: ResourceBar("Stamina"),
+               },
 		BackgroundColor3: Color3.fromRGB(30, 30, 30),
 		BorderSizePixel: 0,
 	});
 
 	/* Organism */
-	const organism = GamePanel({
-		Name: "CharacterInfoCard",
-		Size: new UDim2(0, 300, 0, 105),
-		BackgroundTransparency: 0.5,
-		BorderSizePixel: 0,
-		Layout: Layout.HorizontalSet(0),
-		LayoutOrder: layoutOrder ?? 1,
-		Content: {
-			Avatar: AvatarBust(Players.LocalPlayer.UserId),
-			ResourceBars: ResourceBarContainer,
-		},
-	});
+       const organism = ListContainer({
+               Name: "CharacterInfoCard",
+               Size: new UDim2(0, 300, 0, 105),
+               BackgroundTransparency: 0.5,
+               BorderSizePixel: 0,
+               LayoutOrientation: "horizontal",
+               LayoutOrder: layoutOrder ?? 1,
+               Content: {
+                       Avatar: AvatarBust(Players.LocalPlayer.UserId),
+                       ResourceBars: ResourceBarContainer,
+               },
+       });
 
 	return organism;
 };

--- a/src/client/ui/organisms/ProgressionCard.ts
+++ b/src/client/ui/organisms/ProgressionCard.ts
@@ -7,18 +7,18 @@
  * @description Displays level gem and experience bar together.
  */
 
-import { GamePanel } from "../atoms";
-import { Layout } from "../tokens";
+import { ListContainer } from "../atoms";
 import { LevelGem } from "../molecules/LevelGem";
 import { ExperienceBar } from "../molecules/ExperienceBar";
 
 export const ProgressionCard = (layoutOrder?: number) => {
-	return GamePanel({
-		Name: "ProgressionCard",
-		Size: new UDim2(0, 250, 0, 70),
-		Layout: Layout.HorizontalSet(5),
-		LayoutOrder: layoutOrder,
-		BackgroundTransparency: 0.5,
+       return ListContainer({
+               Name: "ProgressionCard",
+               Size: new UDim2(0, 250, 0, 70),
+               LayoutOrientation: "horizontal",
+               Gap: 5,
+               LayoutOrder: layoutOrder,
+               BackgroundTransparency: 0.5,
 		Content: {
 			Level: LevelGem(),
 			XP: ExperienceBar(),

--- a/src/client/ui/organisms/ResourceBar.ts
+++ b/src/client/ui/organisms/ResourceBar.ts
@@ -22,7 +22,7 @@
  */
 
 // -------------- Imports ----------------------------------------------------- //
-import { GamePanel } from "client/ui/atoms"; // absolute alias
+import { BaseContainer } from "client/ui/atoms"; // absolute alias
 import { BarMeter } from "client/ui/molecules/FillBar/BarMeter";
 import ResourceSlice from "client/states/ResourceSlice";
 import { ResourceKey, ResourceMeta } from "shared/definitions/Resources";
@@ -32,8 +32,8 @@ import { Computed } from "@rbxts/fusion";
 export function ResourceBar(resourceKey: ResourceKey) {
 	const state = ResourceSlice.getInstance().Resources[resourceKey];
 	const meta = ResourceMeta[resourceKey];
-	const resourceBarContainer = GamePanel({
-		Name: `${resourceKey}BarContainer`,
+       const resourceBarContainer = BaseContainer({
+               Name: `${resourceKey}BarContainer`,
 		Size: UDim2.fromScale(1, 0.3),
 		LayoutOrder: meta.layoutOrder,
 		Content: {

--- a/src/client/ui/screens/GemForgeScreen.ts
+++ b/src/client/ui/screens/GemForgeScreen.ts
@@ -22,32 +22,32 @@
 
 import { GameWindow } from "../molecules";
 import { ScreenKey } from "client/states";
-import { GamePanel } from "../atoms";
-import { Layout, Padding } from "../tokens";
+import { ListContainer } from "../atoms";
+import { Padding } from "../tokens";
 import { GemSlotKey } from "shared";
 const Key: ScreenKey = "GemForge";
 
 const GemSlot = (slotKey: GemSlotKey) => {
-	const container = GamePanel({
-		Name: `${Key}_${slotKey}Slot`,
-		Size: new UDim2(1, 0, 0, 100),
-		Padding: Padding(5),
-		Layout: Layout.HorizontalScroll(),
-		BackgroundTransparency: 0,
-		Content: [],
-	});
+       const container = ListContainer({
+               Name: `${Key}_${slotKey}Slot`,
+               Size: new UDim2(1, 0, 0, 100),
+               Padding: Padding(5),
+               LayoutOrientation: "horizontal",
+               BackgroundTransparency: 0,
+               Content: [],
+       });
 
 	return container;
 };
 
 const GemSlotContainer = () => {
-	const SubPanel = GamePanel({
-		Name: `${Key}_SlotPanel`,
-		Size: new UDim2(0.5, 0, 1, 0),
-		Padding: Padding(5),
-		Layout: Layout.VerticalScroll(),
-		BackgroundTransparency: 0.5,
-		Content: {
+       const SubPanel = ListContainer({
+               Name: `${Key}_SlotPanel`,
+               Size: new UDim2(0.5, 0, 1, 0),
+               Padding: Padding(5),
+               LayoutOrientation: "vertical",
+               BackgroundTransparency: 0.5,
+               Content: {
 			FormSlot: GemSlot("FORM"),
 			AbilitySlot: GemSlot("ABILITY"),
 			PhysicalSlot: GemSlot("PHYSICAL"),

--- a/src/client/ui/screens/PlayerHUDScreen.ts
+++ b/src/client/ui/screens/PlayerHUDScreen.ts
@@ -7,7 +7,7 @@
  * @description Primary heads-up display shown during gameplay.
  */
 
-import { GamePanel, GameScreen, ListContainer } from "../atoms";
+import { BaseContainer, GameScreen, ListContainer } from "../atoms";
 import { HUDMenuBar, AbilityBarComponent, ProgressionCard } from "client/ui/organisms";
 import { CharacterInfoCard } from "../organisms";
 import { Padding } from "../tokens";
@@ -23,7 +23,7 @@ export const PlayerHUDScreen = () => {
 		layoutOrder: 2,
 	});
 	/* HUD Container */
-	const HUDContainer = GamePanel({
+       const HUDContainer = BaseContainer({
 		Name: "HUDContainer",
 		Size: new UDim2(1, 0, 1, 0),
 		BackgroundTransparency: 1,


### PR DESCRIPTION
## Summary
- replace all usages of `GamePanel` with `BaseContainer` or `ListContainer`
- mark `GamePanel` as deprecated and remove barrel export
- add themable defaults to `ListContainer`
- update examples and references in documentation

## Testing
- `npm run build`
- `npm test` *(fails: rbxts/testez not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d275debcc83279cdbd99d76167928