### PR TITLE
Fix color tokens

### DIFF
--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -30,11 +30,15 @@ The table below lists core modules grouped by network layer and their current st
 |Client|`client/ui/atoms/Button/UIButton.ts`|Usable|Unified button primitive|
 |Client|`client/ui/atoms/Button/DraggableButton.ts`|Usable|Wrapper preset for draggable buttons|
 |Client|`client/ui/molecules/CountdownTimer.ts`|Usable|Displays battle countdown|
-|Client|`client/ui/molecules/GameWindow.ts`|Usable|Panel window with title bar|
+|Client|`client/ui/atoms/GameWindow.ts`|Usable|Panel window with title bar|
 |Client|`client/ui/molecules/TitleBar.ts`|Usable|Window title bar component|
 |Client|`client/ui/molecules/SettingListItem.ts`|Usable|Displays and edits a single setting|
 |Client|`client/ui/molecules/ExperienceBar.ts`|Usable|Displays experience progress|
 |Client|`client/ui/molecules/LevelGem.ts`|Usable|Shows current level|
+|Client|`client/ui/molecules/ProgressBar.ts`|Usable|Basic progress bar|
+|Client|`client/ui/molecules/BarMeter.ts`|Usable|Tokenized bar meter|
+|Client|`client/ui/molecules/HUDMenuButton.ts`|Usable|HUD toggle button|
+|Client|`client/ui/molecules/AbilityInfoPanel.ts`|Usable|Ability description panel|
 |Client|`client/ui/molecules/UserMessage.ts`|Usable|Center-screen popup messages|
 |Client|`client/states/SettingsState.ts`|Usable|Reactive settings container|
 |Client|`client/network/ClientNetworkService.ts`|Usable|Client RPC helpers|

--- a/src/client/ui/atoms/Badge.ts
+++ b/src/client/ui/atoms/Badge.ts
@@ -14,13 +14,14 @@
  * @author       Trembus
  * @license      MIT
  * @since        0.2.0
- * @lastUpdated  2025-07-09 by Trembus – Initial creation
+ * @lastUpdated  2025-07-10 by Codex – Tokenized colours
  *
  * @dependencies
  *   @rbxts/fusion ^0.4.0
  */
 
 import { Children, Computed, New, PropertyTable, Value } from "@rbxts/fusion";
+import { useToken } from "theme/hooks";
 
 export interface BadgeProps extends PropertyTable<TextButton> {
 	TextValue: Value<string>; // Text displayed on the badge
@@ -41,25 +42,28 @@ export const Badge = (props: BadgeProps) => {
 		}
 	});
 
-	// Create the badge button with an icon and text
+        // Create the badge button with an icon and text
+        const bg = props.BackgroundColor3 ?? useToken("panelBorder");
+        const text = props.TextColor3 ?? useToken("textPrimary");
+        const stroke = props.TextStrokeColor3 ?? useToken("textSecondary");
 
-	const button = New("TextButton")({
-		Name: props.Name ?? "Badge",
-		AnchorPoint: new Vector2(0.5, 0.5), // Center the badge
-		Position: Position,
-		Size: props.Size ?? UDim2.fromOffset(34, 34),
-		BackgroundTransparency: 0,
-		BackgroundColor3: props.BackgroundColor3 ?? new Color3(1, 0, 0), // Default red background
-		Text: Computed(() => props.TextValue.get()),
-		ZIndex: props.ZIndex ?? 10000,
-		LayoutOrder: props.LayoutOrder ?? 0,
-		TextColor3: props.TextColor3 ?? new Color3(1, 1, 1), // Default white text
-		TextStrokeColor3: props.TextStrokeColor3 ?? new Color3(0, 0, 0), // Default black stroke
-		TextStrokeTransparency: props.TextStrokeTransparency ?? 0.5, // Default stroke transparency
-		TextSize: props.TextSize ?? 14,
-		[Children]: {
-			Corner: New("UICorner")({
-				CornerRadius: new UDim(0, 8), // Rounded corners
+        const button = New("TextButton")({
+                Name: props.Name ?? "Badge",
+                AnchorPoint: new Vector2(0.5, 0.5), // Center the badge
+                Position: Position,
+                Size: props.Size ?? UDim2.fromOffset(34, 34),
+                BackgroundTransparency: 0,
+                BackgroundColor3: bg,
+                Text: Computed(() => props.TextValue.get()),
+                ZIndex: props.ZIndex ?? 10000,
+                LayoutOrder: props.LayoutOrder ?? 0,
+                TextColor3: text,
+                TextStrokeColor3: stroke,
+                TextStrokeTransparency: props.TextStrokeTransparency ?? 0.5, // Default stroke transparency
+                TextSize: props.TextSize ?? 14,
+                [Children]: {
+                        Corner: New("UICorner")({
+                                CornerRadius: new UDim(0, 8), // Rounded corners
 			}),
 		},
 	});

--- a/src/client/ui/atoms/GameWindow.ts
+++ b/src/client/ui/atoms/GameWindow.ts
@@ -14,13 +14,14 @@
  * @author       Codex
  * @license      MIT
  * @since        0.2.1
- * @lastUpdated  2025-07-02 by Codex – Initial creation
+ * @lastUpdated  2025-07-10 by Codex – Tokenized title colours
  *
  * @dependencies
  *   @rbxts/fusion ^0.4.0
  */
 
 import Fusion, { Children, New, OnEvent } from "@rbxts/fusion";
+import { useToken } from "theme/hooks";
 import { BaseContainer } from ".";
 import { Players } from "@rbxts/services";
 import { GameImages } from "shared/assets";
@@ -30,9 +31,11 @@ import { Padding } from "../tokens";
 const DEFAULT_WINDOW_SIZE = new UDim2(0.5, 0, 0.5, 0);
 
 export interface GameWindowProps extends Fusion.PropertyTable<Frame> {
-	Title?: string;
-	ScreenKey: ScreenKey;
-	Content?: Fusion.ChildrenValue;
+        Title?: string;
+        ScreenKey: ScreenKey;
+        Content?: Fusion.ChildrenValue;
+        TitleColor?: Color3 | Fusion.Computed<Color3>;
+        TitleStrokeColor?: Color3 | Fusion.Computed<Color3>;
 }
 
 export function GameWindow(props: GameWindowProps) {
@@ -44,15 +47,18 @@ export function GameWindow(props: GameWindowProps) {
 	props.Parent = props.Parent ?? Players.LocalPlayer.WaitForChild("PlayerGui");
 
 	/* Title Bar */
-	const titleBar = New("TextLabel")({
-		Name: "TitleText",
-		Size: UDim2.fromScale(1, 0.1),
-		Position: UDim2.fromScale(0, 0),
-		Text: props.Title,
-		BackgroundTransparency: 0.95,
-		TextColor3: Color3.fromRGB(255, 255, 255),
-		TextStrokeColor3: Color3.fromRGB(0, 0, 0),
-		TextStrokeTransparency: 0.5,
+        const textColour = props.TitleColor ?? useToken("textPrimary");
+        const strokeColour = props.TitleStrokeColor ?? useToken("textSecondary");
+
+        const titleBar = New("TextLabel")({
+                Name: "TitleText",
+                Size: UDim2.fromScale(1, 0.1),
+                Position: UDim2.fromScale(0, 0),
+                Text: props.Title,
+                BackgroundTransparency: 0.95,
+                TextColor3: textColour,
+                TextStrokeColor3: strokeColour,
+                TextStrokeTransparency: 0.5,
 		TextSize: 25,
 		Font: Enum.Font.SourceSansBold,
 		TextXAlignment: Enum.TextXAlignment.Center,

--- a/src/client/ui/molecules/AbilityInfoPanel.ts
+++ b/src/client/ui/molecules/AbilityInfoPanel.ts
@@ -1,13 +1,16 @@
 import { AbilitiesMeta, AbilityKey } from "shared/definitions/ProfileDefinitions/Ability";
 import { BaseContainer, ListContainer, GameImage, GameText } from "../atoms";
-import { New, Value } from "@rbxts/fusion";
+import { New, Value, Computed } from "@rbxts/fusion";
+import { useToken } from "theme/hooks";
 
 export interface AbilityInfoPanelProps {
-	abilityKey: AbilityKey;
+        abilityKey: AbilityKey;
+        CooldownColor?: Color3 | Computed<Color3>;
+        PowerColor?: Color3 | Computed<Color3>;
 }
 
-export function AbilityInfoPanel({ abilityKey }: AbilityInfoPanelProps) {
-	const abilityMeta = AbilitiesMeta[abilityKey];
+export function AbilityInfoPanel({ abilityKey, CooldownColor, PowerColor }: AbilityInfoPanelProps) {
+        const abilityMeta = AbilitiesMeta[abilityKey];
 
 	const abilityIcon = GameImage({
 		Name: `AbilityIcon-${abilityKey}`,
@@ -26,20 +29,23 @@ export function AbilityInfoPanel({ abilityKey }: AbilityInfoPanelProps) {
 		Size: UDim2.fromScale(1, 0.3),
 		TextWrapped: true,
 	});
-	const abilityCooldown = GameText({
-		Name: `AbilityCooldown-${abilityKey}`,
-		TextStateValue: Value(`Cooldown: ${abilityMeta.cooldown} seconds`),
-		Size: UDim2.fromScale(1, 0.3),
-		BackgroundTransparency: 1,
-		TextColor3: Color3.fromRGB(255, 100, 100), //
-	});
-	const abilityPower = GameText({
-		Name: `AbilityPower-${abilityKey}`,
-		TextStateValue: Value(`Base Power: ${abilityMeta.basePower}`),
-		BackgroundTransparency: 1,
-		TextColor3: Color3.fromRGB(100, 255, 100), //
-		Size: UDim2.fromScale(1, 0.3),
-	});
+        const cooldownColor = CooldownColor ?? useToken("healthFill");
+        const powerColor = PowerColor ?? useToken("staminaFill");
+
+        const abilityCooldown = GameText({
+                Name: `AbilityCooldown-${abilityKey}`,
+                TextStateValue: Value(`Cooldown: ${abilityMeta.cooldown} seconds`),
+                Size: UDim2.fromScale(1, 0.3),
+                BackgroundTransparency: 1,
+                TextColor3: cooldownColor,
+        });
+        const abilityPower = GameText({
+                Name: `AbilityPower-${abilityKey}`,
+                TextStateValue: Value(`Base Power: ${abilityMeta.basePower}`),
+                BackgroundTransparency: 1,
+                TextColor3: powerColor,
+                Size: UDim2.fromScale(1, 0.3),
+        });
 
 	return ListContainer({
 		Name: `AbilityInfoPanel-${abilityKey}`,

--- a/src/client/ui/molecules/BarMeter.ts
+++ b/src/client/ui/molecules/BarMeter.ts
@@ -14,7 +14,7 @@
  * @author       Codex
  * @license      MIT
  * @since        0.2.1
- * @lastUpdated  2025-07-01 by Codex – Initial creation
+ * @lastUpdated  2025-07-10 by Codex – Tokenized text color
  *
  * @dependencies
  *   @rbxts/fusion ^0.4.0
@@ -22,13 +22,15 @@
 
 import Fusion, { Children, New, Value, Computed, OnChange } from "@rbxts/fusion";
 import { BorderImage, BaseContainer, GameText } from "../atoms";
+import { useToken } from "theme/hooks";
 
 export interface BarMeterProps extends Fusion.PropertyTable<Frame> {
-	ProgressState?: Computed<number>;
-	CurrentValue?: Value<number>;
-	MaxValue?: Value<number>;
-	Gradient?: UIGradient;
-	Text?: string;
+        ProgressState?: Computed<number>;
+        CurrentValue?: Value<number>;
+        MaxValue?: Value<number>;
+        Gradient?: UIGradient;
+        Text?: string;
+        TextColor3?: Color3 | Fusion.Computed<Color3>;
 }
 
 export function BarMeter(props: BarMeterProps) {
@@ -52,15 +54,17 @@ export function BarMeter(props: BarMeterProps) {
 	});
 
 	/* Text Label */
-	const TextLabel = GameText({
-		TextStateValue: TextValue,
-		Size: UDim2.fromScale(0.9, 0.9),
-		AnchorPoint: new Vector2(0.5, 0.5),
-		Position: new UDim2(0.5, 0, 0.5, 0),
-		TextScaled: true,
-		TextColor3: Color3.fromRGB(255, 255, 255),
-		ZIndex: 100,
-	});
+        const textColour = props.TextColor3 ?? useToken("textPrimary");
+
+        const TextLabel = GameText({
+                TextStateValue: TextValue,
+                Size: UDim2.fromScale(0.9, 0.9),
+                AnchorPoint: new Vector2(0.5, 0.5),
+                Position: new UDim2(0.5, 0, 0.5, 0),
+                TextScaled: true,
+                TextColor3: textColour,
+                ZIndex: 100,
+        });
 
 	/* Container */
 	const container = BaseContainer({

--- a/src/client/ui/molecules/HUDMenuButton.ts
+++ b/src/client/ui/molecules/HUDMenuButton.ts
@@ -12,32 +12,45 @@
  * ╰───────────────────────────────╯
  *
  * @since        0.2.1
- * @lastUpdated  2025-07-05 by Codex – Documentation cleanup
+ * @lastUpdated  2025-07-10 by Codex – Exposed state colours
  */
 
 import Fusion, { Children, Computed, New, OnEvent, Value } from "@rbxts/fusion";
+import { useToken } from "theme/hooks";
 import { GameImage, UIButton } from "client/ui/atoms";
 import { GameImages, MenuButtonImageMap } from "shared";
 import { ScreenKey, ShowScreen, ScreenState } from "client/states";
 
 export interface HUDMenuButtonProps extends Fusion.PropertyTable<ImageButton> {
-	/** Which screen this button toggles. */
-	ScreenKey: ScreenKey;
+        /** Which screen this button toggles. */
+        ScreenKey: ScreenKey;
+        DefaultColour?: Color3 | Fusion.Computed<Color3>;
+        HoverColour?: Color3 | Fusion.Computed<Color3>;
+        SelectedColour?: Color3 | Fusion.Computed<Color3>;
 }
 
 /* =============================== HUDMenuButton Component ====================== */
 export const HUDMenuButton = (props: HUDMenuButtonProps) => {
-	const SelectedState = ScreenState[props.ScreenKey] ?? Value(false);
-	const Hovered = Value(false);
+        const SelectedState = ScreenState[props.ScreenKey] ?? Value(false);
+        const Hovered = Value(false);
 
-	const computedBGColor = Computed(() => {
-		if (SelectedState.get()) {
-			return new Color3(0.75, 0.29, 0.29);
-		} else if (Hovered.get()) {
-			return new Color3(0.87, 0.94, 0.53);
-		}
-		return new Color3(0.08, 0.04, 0.04);
-	});
+        const toComputed = (colour: Color3 | Fusion.Computed<Color3> | undefined, fallback: Fusion.Computed<Color3>): Fusion.Computed<Color3> => {
+                if (colour === undefined) return fallback;
+                return typeIs(colour, "Color3") ? Computed(() => colour) : (colour as Fusion.Computed<Color3>);
+        };
+
+        const defaultColor = toComputed(props.DefaultColour, useToken("panelBg"));
+        const hoverColor = toComputed(props.HoverColour, useToken("panelBgHover"));
+        const selectedColor = toComputed(props.SelectedColour, useToken("panelBorder"));
+
+        const computedBGColor = Computed(() => {
+                if (SelectedState.get()) {
+                        return selectedColor.get();
+                } else if (Hovered.get()) {
+                        return hoverColor.get();
+                }
+                return defaultColor.get();
+        });
 
 	const button = New("ImageButton")({
 		Name: props.Name ?? "ToggleMenuButton",
@@ -63,7 +76,7 @@ export const HUDMenuButton = (props: HUDMenuButtonProps) => {
 				BackgroundTransparency: 1,
 				Position: UDim2.fromScale(0.5, 0.5),
 				AnchorPoint: new Vector2(0.5, 0.5),
-				ImageColor3: new Color3(1, 1, 1), // White
+                                ImageColor3: props.ImageColor3 ?? new Color3(1, 1, 1),
 			}),
 		},
 	});

--- a/src/client/ui/molecules/ProgressBar.ts
+++ b/src/client/ui/molecules/ProgressBar.ts
@@ -14,7 +14,7 @@
  * @author       Trembus
  * @license      MIT
  * @since        0.2.1
- * @lastUpdated  2025-07-09 by Trembus – Initial creation
+ * @lastUpdated  2025-07-10 by Codex – Tokenized background color
  *
  * @dependencies
  *   @rbxts/fusion ^0.4.0
@@ -22,6 +22,7 @@
 
 import Fusion, { Children, Computed, New, PropertyTable, Value } from "@rbxts/fusion";
 import { GameText } from "../atoms";
+import { useToken } from "theme/hooks";
 
 export interface ProgressBarProps extends Partial<PropertyTable<Frame>> {
 	Progress: Computed<number>; // Value between 0 and 1 representing progress
@@ -60,7 +61,7 @@ export const ProgressBar = (props: ProgressBarProps) => {
 		Size: props.Size ?? UDim2.fromScale(1, 1),
 		AnchorPoint: props.AnchorPoint ?? new Vector2(0, 0),
 		Position: props.Position ?? UDim2.fromScale(0, 0),
-		BackgroundColor3: new Color3(0.03, 0.02, 0.02),
+                BackgroundColor3: props.BackgroundColor3 ?? useToken("panelBg"),
 		LayoutOrder: props.LayoutOrder ?? 0,
 		[Children]: {
 			Fill: fillBar,

--- a/src/client/ui/molecules/UserMessage.ts
+++ b/src/client/ui/molecules/UserMessage.ts
@@ -14,7 +14,7 @@
  * @author       Codex
  * @license      MIT
  * @since        0.2.1
- * @lastUpdated  2025-07-06 by Codex – Initial creation
+ * @lastUpdated  2025-07-10 by Codex – Tokenized error colour
  *
  * @dependencies
  *   @rbxts/fusion ^0.4.0
@@ -30,7 +30,8 @@ const slice = MessageSlice.getInstance();
 export function UserMessage() {
 	const textColor = useToken("textPrimary");
 
-	const colour = Computed(() => (slice.IsError.get() ? Color3.fromRGB(255, 80, 80) : textColor.get()));
+        const errorColor = useToken("healthFill");
+        const colour = Computed(() => (slice.IsError.get() ? errorColor.get() : textColor.get()));
 
 	const label = New("TextLabel")({
 		Name: "MessageLabel",


### PR DESCRIPTION
## Summary
- use theme tokens instead of magic Color3 values
- expose UI colors as props in HUDMenuButton and AbilityInfoPanel
- update development summary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e75b84ffc83278968396ca94157a7