### PR TITLE
Move HUDMenuButton to organisms

### DIFF
--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -37,7 +37,7 @@ The table below lists core modules grouped by network layer and their current st
 |Client|`client/ui/molecules/LevelGem.ts`|Usable|Shows current level|
 |Client|`client/ui/molecules/ProgressBar.ts`|Usable|Basic progress bar|
 |Client|`client/ui/molecules/BarMeter.ts`|Usable|Tokenized bar meter|
-|Client|`client/ui/molecules/HUDMenuButton.ts`|Usable|HUD toggle button|
+|Client|`client/ui/organisms/HUDMenuButton.ts`|Usable|HUD toggle button|
 |Client|`client/ui/molecules/AbilityInfoPanel.ts`|Usable|Ability description panel|
 |Client|`client/ui/molecules/UserMessage.ts`|Usable|Center-screen popup messages|
 |Client|`client/states/SettingsState.ts`|Usable|Reactive settings container|

--- a/src/client/ui/molecules/index.ts
+++ b/src/client/ui/molecules/index.ts
@@ -15,7 +15,6 @@ export * from "./AbilityInfoPanel";
 export * from "./BarMeter";
 export * from "./CountdownTimer";
 export * from "./ExperienceBar";
-export * from "./HUDMenuButton";
 export * from "./LevelGem";
 export * from "./ProgressBar";
 export * from "./UserMessage";

--- a/src/client/ui/organisms/Groups/HUDMenuBar.ts
+++ b/src/client/ui/organisms/Groups/HUDMenuBar.ts
@@ -7,7 +7,7 @@
  * @description Horizontal container of HUD menu buttons.
  */
 import { ListContainer } from "client/ui/atoms";
-import { HUDMenuButton } from "client/ui/molecules/HUDMenuButton";
+import { HUDMenuButton } from "client/ui/organisms/HUDMenuButton";
 import { GameImages, MenuButtonImageMap } from "shared/assets";
 import { SCREEN_KEYS, ScreenKey, ScreenOrder } from "client/states";
 import { Badge } from "client/ui/atoms/Badge";

--- a/src/client/ui/organisms/HUDMenuButton.ts
+++ b/src/client/ui/organisms/HUDMenuButton.ts
@@ -3,7 +3,7 @@
 /**
  * @file        HUDMenuButton.ts
  * @module      HUDMenuButton
- * @layer       Client/UI/Molecules/Button
+ * @layer       Client/UI/Organisms
  * @description Toggle button used in the HUD menu bar to show or hide screens.
  *
  * ╭───────────────────────────────╮

--- a/src/client/ui/organisms/index.ts
+++ b/src/client/ui/organisms/index.ts
@@ -14,3 +14,4 @@ export * from "./Groups";
 export * from "./AttributeControls";
 export * from "./ProgressionCard";
 export * from "./ResourceBar";
+export * from "./HUDMenuButton";


### PR DESCRIPTION
## Summary
- relocate HUDMenuButton from molecules folder into organisms
- adjust barrel exports and imports
- update development summary

## Testing
- `npm run lint`
- `node .codex/runTests.js`
- `npx nx run tools:lint` *(failed: No existing Nx Cloud client and failed to download new version)*

------
https://chatgpt.com/codex/tasks/task_e_686e7a0cc4248327a0eb0654efa7f9c3