### PR TITLE
Add service audit utility

### DIFF
--- a/codexUtility/serviceLoadAudit.js
+++ b/codexUtility/serviceLoadAudit.js
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * @file        serviceLoadAudit.js
+ * @module      ServiceLoadAudit
+ * @description Generates service dependency graph and load order reports.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · codexUtility    │
+ * ╰───────────────────────────────╯
+ *
+ * Simple static analysis over server Services to detect dependency edges,
+ * initialization order and potential architectural issues.
+ */
+const fs = require('fs');
+const path = require('path');
+const ts = require('typescript');
+
+const repoRoot = path.resolve(__dirname, '..');
+const serverDir = path.join(repoRoot, 'src/server');
+const reportsDir = path.join(repoRoot, 'reports');
+
+if (!fs.existsSync(reportsDir)) fs.mkdirSync(reportsDir);
+
+function findServiceFiles(dir) {
+    const res = [];
+    const items = fs.readdirSync(dir, { withFileTypes: true });
+    for (const item of items) {
+        const full = path.join(dir, item.name);
+        if (item.isDirectory()) res.push(...findServiceFiles(full));
+        else if (/Service\.ts$/.test(item.name)) res.push(full);
+    }
+    return res;
+}
+
+const serviceFiles = findServiceFiles(serverDir).filter(f => !f.includes('.test.'));
+
+function getServiceName(file) {
+    const base = path.basename(file).replace(/\.ts$/, '');
+    return base;
+}
+
+const services = new Map();
+serviceFiles.forEach(f => services.set(getServiceName(f), f));
+
+function parseImports(file) {
+    const text = fs.readFileSync(file, 'utf8');
+    const source = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true);
+    const deps = new Set();
+    source.forEachChild(node => {
+        if (ts.isImportDeclaration(node) && node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier)) {
+            const spec = node.moduleSpecifier.text;
+            let resolved = spec;
+            if (spec.startsWith('.')) {
+                resolved = path.resolve(path.dirname(file), spec);
+                if (!resolved.endsWith('.ts')) resolved += '.ts';
+            }
+            for (const [name, sf] of services.entries()) {
+                if (sf === resolved) deps.add(name);
+                else if (resolved.endsWith(name + '.ts')) deps.add(name);
+            }
+        }
+    });
+    return Array.from(deps);
+}
+
+const graph = new Map();
+services.forEach((file, name) => {
+    graph.set(name, parseImports(file));
+});
+
+// Detect cycles via DFS
+function detectCycles() {
+    const visited = new Set();
+    const stack = new Set();
+    const cycles = [];
+    function visit(n) {
+        if (stack.has(n)) return [true];
+        if (visited.has(n)) return [false];
+        visited.add(n);
+        stack.add(n);
+        for (const m of graph.get(n) || []) {
+            const [c] = visit(m);
+            if (c) cycles.push([...stack, m]);
+        }
+        stack.delete(n);
+        return [false];
+    }
+    for (const n of graph.keys()) visit(n);
+    return cycles;
+}
+
+const cycles = detectCycles();
+
+function writeDot() {
+    const lines = ['digraph ServiceDeps {'];
+    graph.forEach((deps, svc) => {
+        if (deps.length === 0) lines.push(`  "${svc}";`);
+        deps.forEach(dep => lines.push(`  "${svc}" -> "${dep}";`));
+    });
+    lines.push('}');
+    fs.writeFileSync(path.join(reportsDir, 'service-deps.dot'), lines.join('\n'), 'utf8');
+    console.log('Service Dependency Edges:');
+    graph.forEach((deps, svc) => {
+        console.log(`- ${svc} -> ${deps.join(', ') || 'None'}`);
+    });
+}
+
+function findAutoStarts() {
+    const events = [];
+    services.forEach((file, name) => {
+        const lines = fs.readFileSync(file, 'utf8').split(/\r?\n/);
+        lines.forEach((line, idx) => {
+            const m = line.match(/(\w+Service)\.Start\(/);
+            if (m) {
+                events.push({ svc: m[1], file, line: idx + 1 });
+            }
+        });
+    });
+    return events;
+}
+
+function parseMain() {
+    const file = path.join(serverDir, 'main.server.ts');
+    const lines = fs.readFileSync(file, 'utf8').split(/\r?\n/);
+    const events = [];
+    lines.forEach((line, idx) => {
+        const m = line.match(/(\w+Service)\.Start/);
+        if (m) events.push({ svc: m[1], file, line: idx + 1 });
+    });
+    return events;
+}
+
+function writeLoadOrder() {
+    const events = [...findAutoStarts(), ...parseMain()];
+    events.sort((a, b) => a.line - b.line);
+    const lines = events.map(e => `${e.svc} -> ${path.relative(repoRoot, e.file)}:${e.line}`);
+    fs.writeFileSync(path.join(reportsDir, 'service-load-order.txt'), lines.join('\n'), 'utf8');
+    console.log('Load Order Timeline:');
+    lines.forEach(l => console.log('  ' + l));
+}
+
+function smellReport() {
+    const lines = [];
+    graph.forEach((deps, svc) => {
+        if (deps.length === 0) lines.push(`INFO: ${svc} has no outgoing deps.`);
+        if (deps.length > 5) lines.push(`WARNING: ${svc} fan-out ${deps.length}.`);
+    });
+    cycles.forEach(c => lines.push(`ERROR: cycle detected ${c.join(' -> ')}`));
+    fs.writeFileSync(path.join(reportsDir, 'service-smells.txt'), lines.join('\n'), 'utf8');
+    console.log('Conflict & Smell Report:');
+    lines.forEach(l => console.log('  ' + l));
+    if (lines.some(l => l.startsWith('ERROR'))) process.exitCode = 1;
+}
+
+function recommendations() {
+    const rec = [];
+    rec.push('Consider implementing a ServiceLoader that declares dependencies explicitly.');
+    rec.push('Services should register themselves but defer Start until dependencies are ready.');
+    rec.push('Example minimal loader:');
+    rec.push('```ts');
+    rec.push('interface ServiceMeta { svc: any; deps: string[] }');
+    rec.push('function load(services: ServiceMeta[]) {');
+    rec.push('  const map = new Map();');
+    rec.push('  const loadSvc = (meta) => {');
+    rec.push('    meta.deps.forEach(d => loadSvc(map.get(d)));');
+    rec.push('    meta.svc.Start();');
+    rec.push('  };');
+    rec.push('  services.forEach(loadSvc);');
+    rec.push('}');
+    rec.push('```');
+    fs.writeFileSync(path.join(reportsDir, 'service-recommendations.txt'), rec.join('\n'), 'utf8');
+    console.log('Architecture Recommendations written.');
+}
+
+writeDot();
+writeLoadOrder();
+smellReport();
+recommendations();
+console.log('✅ Service Load Audit completed – reports available in /reports');
+

--- a/reports/service-deps.dot
+++ b/reports/service-deps.dot
@@ -1,0 +1,18 @@
+digraph ServiceDeps {
+  "AbilityService" -> "DataService";
+  "AbilityService" -> "ResourcesService";
+  "AbilityService" -> "MessageService";
+  "AttributesService" -> "DataService";
+  "AttributesService" -> "ResourcesService";
+  "BattleRoomService";
+  "DataService";
+  "MessageService";
+  "NPCService";
+  "OrganismService";
+  "ProgressionService" -> "DataService";
+  "ResourcesService" -> "DataService";
+  "SSEntityService";
+  "SettingsService";
+  "StatusEffectService";
+  "WeaponService";
+}

--- a/reports/service-load-order.txt
+++ b/reports/service-load-order.txt
@@ -1,0 +1,7 @@
+DataService -> src/server/main.server.ts:20
+ResourcesService -> src/server/main.server.ts:21
+SettingsService -> src/server/services/SettingsService.ts:56
+OrganismService -> src/server/services/OrganismService.ts:66
+ProgressionService -> src/server/services/ProgressionService.ts:72
+StatusEffectService -> src/server/services/StatusEffectService.ts:79
+ResourcesService -> src/server/services/ResourcesService.ts:187

--- a/reports/service-recommendations.txt
+++ b/reports/service-recommendations.txt
@@ -1,0 +1,14 @@
+Consider implementing a ServiceLoader that declares dependencies explicitly.
+Services should register themselves but defer Start until dependencies are ready.
+Example minimal loader:
+```ts
+interface ServiceMeta { svc: any; deps: string[] }
+function load(services: ServiceMeta[]) {
+  const map = new Map();
+  const loadSvc = (meta) => {
+    meta.deps.forEach(d => loadSvc(map.get(d)));
+    meta.svc.Start();
+  };
+  services.forEach(loadSvc);
+}
+```

--- a/reports/service-smells.txt
+++ b/reports/service-smells.txt
@@ -1,0 +1,9 @@
+INFO: BattleRoomService has no outgoing deps.
+INFO: DataService has no outgoing deps.
+INFO: MessageService has no outgoing deps.
+INFO: NPCService has no outgoing deps.
+INFO: OrganismService has no outgoing deps.
+INFO: SSEntityService has no outgoing deps.
+INFO: SettingsService has no outgoing deps.
+INFO: StatusEffectService has no outgoing deps.
+INFO: WeaponService has no outgoing deps.


### PR DESCRIPTION
## Summary
- implement `serviceLoadAudit` to map service dependencies
- generate dependency graph, load order timeline, and recommendations in `/reports`

## Testing
- `npm test`
- `node codexUtility/serviceLoadAudit.js`

------
https://chatgpt.com/codex/tasks/task_e_68739cbc14048327ade5a441782e95d7