### PR TITLE
Implement CombatService with kill credit

### DIFF
--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -74,6 +74,7 @@ The table below lists core modules grouped by network layer and their current st
 |Server|`server/services/PlayerLifecycleService.ts`|Usable|Manages player join & respawn|
 |Server|`server/services/AttributesService.ts`|Under Construction|Validates attribute changes|
 |Server|`server/services/ProgressionService.ts`|Under Construction|Manages experience and level ups|
+|Server|`server/services/CombatService.ts`|Under Construction|Tracks damage & kill credit|
 |Server|`server/entity/npc/NPC.ts`|Usable|NPC instance with random names|
 |Server|`server/entity/entityResource/EntityResource.ts`|Usable|Drops collectible resource|
 |Server|`server/entity/EvolvingOrganism.ts`|Under Construction|DNA‑driven organism|

--- a/src/server/services/CombatService.spec.ts
+++ b/src/server/services/CombatService.spec.ts
@@ -1,0 +1,62 @@
+/// <reference types="@rbxts/testez/globals" />
+import { Workspace } from "@rbxts/services";
+import { CombatService } from "./CombatService";
+import { createDamageBucket } from "shared/combat";
+import { SSEntity } from "shared/types/SSEntity";
+
+function createEntity(name: string): SSEntity {
+	const model = new Instance("Model");
+	model.Name = name;
+	const humanoid = new Instance("Humanoid");
+	humanoid.Parent = model;
+	const hrp = new Instance("Part");
+	hrp.Name = "HumanoidRootPart";
+	hrp.Parent = model;
+	(model as unknown as { Humanoid: Humanoid; HumanoidRootPart: BasePart; PrimartyPart: BasePart }).Humanoid =
+		humanoid;
+	(model as unknown as { HumanoidRootPart: BasePart }).HumanoidRootPart = hrp;
+	(model as unknown as { PrimartyPart: BasePart }).PrimartyPart = hrp;
+	model.Parent = Workspace;
+	return model as unknown as SSEntity;
+}
+
+export = () => {
+	describe("CombatService", () => {
+		it("awards kill credit to highest contributor", () => {
+			const attacker = createEntity("A");
+			const defender = createEntity("D");
+			CombatService.RegisterEntity(attacker);
+			CombatService.RegisterEntity(defender);
+			let result: unknown;
+			const conn = CombatService.onDeath((sum) => (result = sum));
+			CombatService.CombatEvent(attacker, defender, createDamageBucket(50, "Blood"));
+			defender.Humanoid.Health = 0;
+			task.wait();
+			expect((result as { victim: SSEntity }).victim).to.equal(defender);
+			expect((result as { killer?: SSEntity }).killer).to.equal(attacker);
+			conn.Disconnect();
+			attacker.Destroy();
+			defender.Destroy();
+		});
+
+		it("requires minimum share for credit", () => {
+			const atk1 = createEntity("atk1");
+			const atk2 = createEntity("atk2");
+			const def = createEntity("def");
+			CombatService.RegisterEntity(atk1);
+			CombatService.RegisterEntity(atk2);
+			CombatService.RegisterEntity(def);
+			let res: unknown;
+			const conn = CombatService.onDeath((s) => (res = s));
+			CombatService.CombatEvent(atk1, def, createDamageBucket(5, "Blood"));
+			CombatService.CombatEvent(atk2, def, createDamageBucket(20, "Blood"));
+			def.Humanoid.Health = 0;
+			task.wait();
+			expect((res as { killer?: SSEntity }).killer).to.equal(atk2);
+			conn.Disconnect();
+			atk1.Destroy();
+			atk2.Destroy();
+			def.Destroy();
+		});
+	});
+};

--- a/src/server/services/CombatService.ts
+++ b/src/server/services/CombatService.ts
@@ -1,0 +1,109 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        CombatService.ts
+ * @module      CombatService
+ * @layer       Server/Services
+ * @description Tracks combat interactions and awards kill credit.
+ *
+ * ╭──────────────────────────────╮
+ * │  Soul Steel · Coding Guide   │
+ * │  Fusion v4 · Strict TS · ECS │
+ * ╰──────────────────────────────╯
+ *
+ * @author       Codex
+ * @license      MIT
+ * @since        0.2.0
+ */
+
+import Signal from "@rbxts/signal";
+import { SSEntity } from "shared/types/SSEntity";
+import { DamageBucket, ContributionEntry, decayScore, qualifiesForKill } from "shared/combat";
+
+interface EntityState {
+	total: number;
+	contributions: Map<SSEntity, ContributionEntry>;
+	diedConn?: RBXScriptConnection;
+}
+
+interface DeathSummary {
+	killer?: SSEntity;
+	victim: SSEntity;
+}
+
+/** Server-authoritative combat bookkeeping. */
+export class CombatService {
+	private static _instance: CombatService | undefined;
+	private readonly _entities = new Map<SSEntity, EntityState>();
+	private readonly _deathSignal = new Signal<(summary: DeathSummary) => void>();
+
+	private readonly halfLifeMs = 5000;
+	private readonly minShare = 0.25;
+
+	private constructor() {}
+
+	/** Initialise internal tables and ensure singleton instance. */
+	public static Start(): CombatService {
+		if (!this._instance) {
+			this._instance = new CombatService();
+		}
+		return this._instance;
+	}
+
+	/** Subscribe to death events summarised by the service. */
+	public static onDeath(cb: (summary: DeathSummary) => void) {
+		return this.Start()._deathSignal.Connect(cb);
+	}
+
+	/** Register an entity once it enters the world. */
+	public static RegisterEntity(entity: SSEntity): void {
+		const svc = this.Start();
+		if (svc._entities.has(entity)) return;
+
+		const state: EntityState = { total: 0, contributions: new Map() };
+		svc._entities.set(entity, state);
+
+		const humanoid = entity.Humanoid;
+		state.diedConn = humanoid.Died.Connect(() => svc.handleDeath(entity));
+	}
+
+	/** Record a combat interaction. */
+	public static CombatEvent(attacker: SSEntity, defender: SSEntity, bucket: DamageBucket): void {
+		const svc = this.Start();
+		const state = svc._entities.get(defender);
+		if (!state) return;
+
+		state.total += bucket.amount;
+		const now = bucket.timestamp;
+		const entry = state.contributions.get(attacker) || { amount: 0, lastHit: now };
+		entry.amount += bucket.amount;
+		entry.lastHit = now;
+		state.contributions.set(attacker, entry);
+	}
+
+	private handleDeath(defender: SSEntity) {
+		const state = this._entities.get(defender);
+		if (!state) return;
+		const now = os.clock() * 1000;
+
+		let topKiller: SSEntity | undefined;
+		let topScore = 0;
+		let total = 0;
+
+		state.contributions.forEach((entry) => {
+			total += decayScore(entry, now, this.halfLifeMs);
+		});
+
+		state.contributions.forEach((entry, attacker) => {
+			const score = decayScore(entry, now, this.halfLifeMs);
+			if (score > topScore && qualifiesForKill(score, total, this.minShare)) {
+				topScore = score;
+				topKiller = attacker;
+			}
+		});
+
+		this._deathSignal.Fire({ killer: topKiller, victim: defender });
+		state.diedConn?.Disconnect();
+		this._entities.delete(defender);
+	}
+}

--- a/src/server/services/index.ts
+++ b/src/server/services/index.ts
@@ -43,3 +43,4 @@ export * from "./AttributesService";
 export * from "./ProgressionService";
 export * from "./WeaponService";
 export * from "./OrganismService";
+export * from "./CombatService";

--- a/src/shared/combat/DamageBucket.ts
+++ b/src/shared/combat/DamageBucket.ts
@@ -1,0 +1,48 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        DamageBucket.ts
+ * @module      DamageBucket
+ * @layer       Shared/Combat
+ * @description Immutable representation of a single damage instance.
+ *
+ * ╭──────────────────────────────╮
+ * │  Soul Steel · Coding Guide   │
+ * │  Fusion v4 · Strict TS · ECS │
+ * ╰──────────────────────────────╯
+ *
+ * @author       Codex
+ * @license      MIT
+ * @since        0.2.0
+ */
+
+import { DomainCategory } from "./DomainCategory";
+
+/**
+ * @interface DamageBucket
+ * Immutable damage descriptor used by combat services.
+ */
+export interface DamageBucket {
+	readonly amount: number;
+	readonly type: DomainCategory;
+	readonly timestamp: number;
+}
+
+/**
+ * Create a DamageBucket snapshot at the current time.
+ * @param amount - Raw damage dealt.
+ * @param type - Damage domain or element.
+ * @returns New immutable damage bucket.
+ *
+ * @example
+ * ```ts
+ * const bucket = createDamageBucket(15, "Blood");
+ * ```
+ */
+export function createDamageBucket(amount: number, domain: DomainCategory): DamageBucket {
+	return {
+		amount,
+		type: domain,
+		timestamp: os.clock() * 1000,
+	} as const;
+}

--- a/src/shared/combat/DomainCategory.ts
+++ b/src/shared/combat/DomainCategory.ts
@@ -1,0 +1,27 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        DomainCategory.ts
+ * @module      DomainCategory
+ * @layer       Shared/Combat
+ * @description Damage domain identifiers used for combat calculations.
+ *
+ * ╭──────────────────────────────╮
+ * │  Soul Steel · Coding Guide   │
+ * │  Fusion v4 · Strict TS · ECS │
+ * ╰──────────────────────────────╯
+ *
+ * @author       Codex
+ * @license      MIT
+ * @since        0.2.0
+ */
+
+/**
+ * Known elemental or thematic damage sources.
+ */
+export const DOMAIN_CATEGORIES = ["Blood", "Decay", "Spirit", "Steel"] as const;
+
+/**
+ * All valid domain category strings.
+ */
+export type DomainCategory = (typeof DOMAIN_CATEGORIES)[number];

--- a/src/shared/combat/KillCreditPolicy.ts
+++ b/src/shared/combat/KillCreditPolicy.ts
@@ -1,0 +1,58 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        KillCreditPolicy.ts
+ * @module      KillCreditPolicy
+ * @layer       Shared/Combat
+ * @description Pure helpers for decaying damage scores and kill credit rules.
+ *
+ * ╭──────────────────────────────╮
+ * │  Soul Steel · Coding Guide   │
+ * │  Fusion v4 · Strict TS · ECS │
+ * ╰──────────────────────────────╯
+ *
+ * @author       Codex
+ * @license      MIT
+ * @since        0.2.0
+ */
+
+/**
+ * Accumulated damage contribution for a given attacker.
+ */
+export interface ContributionEntry {
+	amount: number;
+	lastHit: number;
+}
+
+/**
+ * Calculate the current weighted score for a contribution entry.
+ * Damage older than `halfLifeMs` loses half its value.
+ *
+ * @param entry - Contribution record to score.
+ * @param nowMs - Current timestamp in milliseconds.
+ * @param halfLifeMs - Half-life period for decay.
+ * @returns Decayed score between 0 and entry.amount.
+ *
+ * @example
+ * ```ts
+ * const score = decayScore({ amount: 50, lastHit: now - 2000 }, now, 1000);
+ * ```
+ */
+export function decayScore(entry: ContributionEntry, nowMs: number, halfLifeMs: number): number {
+	const elapsed = math.max(nowMs - entry.lastHit, 0);
+	const decayFactor = 0.5 ** (elapsed / halfLifeMs);
+	return entry.amount * decayFactor;
+}
+
+/**
+ * Determine if an attacker qualifies for kill credit.
+ *
+ * @param attackerScore - Attacker's decayed damage value.
+ * @param totalDamage - Sum of all decayed damage values.
+ * @param minShare - Minimum fraction of total required for credit.
+ * @returns True if credit should be granted.
+ */
+export function qualifiesForKill(attackerScore: number, totalDamage: number, minShare: number): boolean {
+	if (totalDamage <= 0) return false;
+	return attackerScore / totalDamage >= minShare;
+}

--- a/src/shared/combat/index.ts
+++ b/src/shared/combat/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @file        src/shared/combat/index.ts
+ * @module      CombatShared
+ * @layer       Shared/Combat
+ * @description Barrel export for combat helpers.
+ */
+
+export * from "./DomainCategory";
+export * from "./DamageBucket";
+export * from "./KillCreditPolicy";

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -22,3 +22,4 @@ export * from "./network";
 export * from "./physics";
 export * from "./genetics";
 export * from "./types";
+export * from "./combat";


### PR DESCRIPTION
## Summary
- add combat helper types and kill credit policy
- implement CombatService for tracking damage
- export new service and helpers
- document new module in development summary
- test kill credit logic

## Testing
- `npm run lint`
- `npm run build`
- `npx rbxts/testez --place build/dunny.rbxlx --verbose` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875315a6624832792b03f6fdd58a572