### PR TITLE
Refactor PlayerLifecycleService

### DIFF
--- a/.codex/prompts/code-audit.md
+++ b/.codex/prompts/code-audit.md
@@ -38,7 +38,8 @@ e:\_Staging/
 server/
 ├── index.ts                    # Barrel export for server modules
 ├── main.server.ts              # Server entry point and bootstrap
-├── services/PlayerLifecycleService.ts # Player lifecycle manager
+├── ServiceWrapper.ts # Lifecycle router
+├── PlayerLifeCycle.ts # Player lifecycle manager
 ├── classes/                    # Server-side class definitions
 │   ├── index.ts               # Barrel export
 │   ├── components/            # ECS-style components

--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -59,7 +59,7 @@ The table below lists core modules grouped by network layer and their current st
 |Client|`client/states/ProgressionSlice.ts`|Usable|Level and experience slice|
 |Client|`client/states/MessageSlice.ts`|Usable|Transient user messages|
 |Client|`client/states/CurrencySlice.ts`|Stub|Currency amounts|
-|Server|`server/main.server.ts`|Under Construction|Bootstraps PlayerLifecycleService|
+|Server|`server/main.server.ts`|Under Construction|Bootstraps ServiceWrapper|
 |Server|`server/network/listener.server.ts`|Usable|Server network handlers|
 |Server|`server/services/DataService.ts`|Usable|Loads player profiles|
 |Server|`server/services/ManifestationForgeService.ts`|Under Construction|Creates manifestations|
@@ -71,7 +71,8 @@ The table below lists core modules grouped by network layer and their current st
 |Server|`server/services/AbilityService.ts`|Usable|Handles ability activation and cooldowns|
 |Server|`server/services/StatusEffectService.ts`|Under Construction|Refactored to use StatusEffects|
 |Server|`server/services/ResourcesService.ts`|Usable|Calculates and syncs resources|
-|Server|`server/services/PlayerLifecycleService.ts`|Usable|Manages player join & respawn|
+|Server|`server/ServiceWrapper.ts`|Under Construction|Routes lifecycle calls|
+|Server|`server/PlayerLifeCycle.ts`|Usable|Manages player join & respawn|
 |Server|`server/services/AttributesService.ts`|Under Construction|Validates attribute changes|
 |Server|`server/services/ProgressionService.ts`|Under Construction|Manages experience and level ups|
 |Server|`server/services/CombatService.ts`|Under Construction|Tracks damage & kill credit|

--- a/src/AGENTS_REPO_MAP.md
+++ b/src/AGENTS_REPO_MAP.md
@@ -34,7 +34,8 @@ e:\_Staging/
 server/
 ├── index.ts                    # Barrel export for server modules
 ├── main.server.ts              # Server entry point and bootstrap
-├── services/PlayerLifecycleService.ts # Player lifecycle manager
+├── ServiceWrapper.ts # Lifecycle router
+├── PlayerLifeCycle.ts # Player lifecycle manager
 ├── classes/                    # Server-side class definitions
 │   ├── index.ts               # Barrel export
 │   ├── components/            # ECS-style components
@@ -217,7 +218,7 @@ Client-server communication is handled through:
 1. Create service file in `src/server/services/`
 2. Extend base service pattern from existing services
 3. Add to services barrel export (`services/index.ts`)
-4. Initialize in `PlayerLifecycleService.ts`
+4. Initialize in `ServiceWrapper.ts`
 5. Update this documentation
 
 ### Creating New Zones

--- a/src/server/PlayerLifeCycle.ts
+++ b/src/server/PlayerLifeCycle.ts
@@ -1,8 +1,8 @@
 /// <reference types="@rbxts/types" />
 
 /**
- * @file        PlayerLifecycleService.ts
- * @module      PlayerLifecycleService
+ * @file        PlayerLifeCycle.ts
+ * @module      PlayerLifeCycle
  * @layer       Server/Services
  * @classType   Singleton
  * @description Handles player joining, spawning, respawning and leaving.
@@ -38,8 +38,8 @@ interface PlayerConnections {
 }
 
 /* =============================================== Service ===================== */
-export class PlayerLifecycleService {
-	private static _instance: PlayerLifecycleService | undefined;
+export class PlayerLifeCycle {
+	private static _instance: PlayerLifeCycle | undefined;
 	private readonly _connections = new Map<Player, PlayerConnections>();
 	private static _heartbeatConnection: RBXScriptConnection | undefined;
 	private readonly _debug: boolean;
@@ -54,16 +54,16 @@ export class PlayerLifecycleService {
 
 		/* -- Gameplay Layer Initialization -- */
 		AbilityService.Start();
-		if (this._debug) print("PlayerLifecycleService started");
+		if (this._debug) print("PlayerLifeCycle started");
 	}
 
 	/**
 	 * @param debug Whether to enable debug logging.
 	 * Destroys the service and cleans up connections.
 	 */
-	public static Start(debug = false): PlayerLifecycleService {
+	public static Start(debug = false): PlayerLifeCycle {
 		if (this._instance === undefined) {
-			this._instance = new PlayerLifecycleService(debug);
+			this._instance = new PlayerLifeCycle(debug);
 			this._runHeartbeat();
 		}
 		return this._instance;
@@ -167,6 +167,6 @@ export class PlayerLifecycleService {
 }
 
 // Auto-start to connect existing players if needed
-//Players.GetPlayers().forEach((player) => PlayerLifecycleService.RegisterPlayer(player));
-// Players.PlayerAdded.Connect((player) => PlayerLifecycleService.RegisterPlayer(player));
-// Players.PlayerRemoving.Connect((player) => PlayerLifecycleService.UnregisterPlayer(player));
+//Players.GetPlayers().forEach((player) => PlayerLifeCycle.RegisterPlayer(player));
+// Players.PlayerAdded.Connect((player) => PlayerLifeCycle.RegisterPlayer(player));
+// Players.PlayerRemoving.Connect((player) => PlayerLifeCycle.UnregisterPlayer(player));

--- a/src/server/ServiceWrapper.ts
+++ b/src/server/ServiceWrapper.ts
@@ -1,0 +1,41 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        ServiceWrapper.ts
+ * @module      ServiceWrapper
+ * @layer       Server/Services
+ * @classType   Facade
+ * @description Pure wrapper that routes lifecycle calls to PlayerLifeCycle.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Codex
+ * @license      MIT
+ * @since        0.2.0
+ * @lastUpdated  2025-07-08 by Codex – Refactored from PlayerLifecycleService
+ *
+ * @dependencies
+ *   ./PlayerLifeCycle
+ */
+
+import { PlayerLifeCycle } from "./PlayerLifeCycle";
+
+export class ServiceWrapper {
+        /** Start the player lifecycle service. */
+        public static Start(debug = false) {
+                PlayerLifeCycle.Start(debug);
+        }
+
+        /** Register a player with the lifecycle service. */
+        public static RegisterPlayer(player: Player) {
+                PlayerLifeCycle.RegisterPlayer(player);
+        }
+
+        /** Unregister a player from the lifecycle service. */
+        public static UnregisterPlayer(player: Player) {
+                PlayerLifeCycle.UnregisterPlayer(player);
+        }
+}

--- a/src/server/main.server.ts
+++ b/src/server/main.server.ts
@@ -8,20 +8,20 @@
  */
 
 /* =============================================== Imports =============================================== */
-import { PlayerLifecycleService } from "./PlayerLifecycleService";
+import { ServiceWrapper } from "./ServiceWrapper";
 import { Players } from "@rbxts/services";
 /* =============================================== Initialization ========================================= */
 
-PlayerLifecycleService.Start(true);
+ServiceWrapper.Start(true);
 
 /* --- Player Added Handler --- */
 function onPlayerAdded(player: Player) {
-	PlayerLifecycleService.RegisterPlayer(player);
+	ServiceWrapper.RegisterPlayer(player);
 }
 
 /* --- Player Removing Handler --- */
 function onPlayerRemoving(player: Player) {
-	PlayerLifecycleService.UnregisterPlayer(player);
+	ServiceWrapper.UnregisterPlayer(player);
 }
 
 /* =============================================== Main Execution ========================================= */


### PR DESCRIPTION
## Summary
- replace `PlayerLifecycleService` with `PlayerLifeCycle` class
- add `ServiceWrapper` facade to route lifecycle calls
- update server entry to use the new wrapper
- document new files in repo map and development summary

## Testing
- `npm run build`
- `npx rbxts/testez --place build/dunny.rbxlx --verbose` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68753752a4b883278e954bf95f905506