### PR TITLE
Add cross-platform Targeting system

### DIFF
--- a/assets/TargetIndicator.rbxm
+++ b/assets/TargetIndicator.rbxm
@@ -1,0 +1,1 @@
+#ASSETREQUEST Simple highlight arrow for target indicator

--- a/design/Targeting.md
+++ b/design/Targeting.md
@@ -1,0 +1,33 @@
+# Targeting System
+
+This document outlines the cross-platform targeting system used in Soul Steel.
+
+## Overview
+
+Players can select a single in-world entity. Combat and UI consume the current target to drive melee attacks and highlight logic. Selection is replicated through rbxts-net events.
+
+```
+Player Input -> TargetingClient -> TargetingService -> TargetSelected event -> UI
+```
+
+## Usage
+
+```ts
+const target = Targeting.getTarget();
+if (target) {
+  CombatService.startAttack(player, target);
+}
+```
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant P as Player
+    participant C as TargetingClient
+    participant S as TargetingService
+    P->>C: requestSelect()
+    C->>S: SelectTarget event
+    S->>C: TargetSelected
+```
+

--- a/src/AGENTS_DEVELOPMENT_SUMMARY.md
+++ b/src/AGENTS_DEVELOPMENT_SUMMARY.md
@@ -5,6 +5,7 @@ The table below lists core modules grouped by network layer and their current st
 | Layer   | Module                                   | Status             | Notes |
 |--------|------------------------------------------|--------------------|-------|
 |Shared|`shared/network`|Rock Solid|Typed event definitions|
+|Shared|`shared/network/targeting.remotes.ts`|Usable|Target selection events|
 |Shared|`shared/data/AbilityData.ts`|Under Construction|Ability metadata|
 |Shared|`shared/data/AttributeData.ts`|Rock Solid|Attribute metadata and helpers|
 |Shared|`shared/data/CodonData.ts`|Rock Solid|Genetic codon constants|
@@ -41,6 +42,7 @@ The table below lists core modules grouped by network layer and their current st
 |Client|`client/states/SettingsState.ts`|Usable|Reactive settings container|
 |Client|`client/network/ClientNetworkService.ts`|Usable|Client RPC helpers|
 |Client|`client/network/listener.client.ts`|Usable|Receives server events|
+|Client|`client/TargetingClient.ts`|Usable|Local target selection helpers|
 |Client|`client/ui/screens`|Under Construction|Gem forge, character, inventory, shop, settings, teleport and HUD screens|
 |Client|`client/ui/screens/DragDropScreen.ts`|Usable|Drag and drop demo|
 |Client|`client/ui/screens/CharacterScreen.ts`|Stub|Character info window|
@@ -76,6 +78,7 @@ The table below lists core modules grouped by network layer and their current st
 |Server|`server/services/AttributesService.ts`|Under Construction|Validates attribute changes|
 |Server|`server/services/ProgressionService.ts`|Under Construction|Manages experience and level ups|
 |Server|`server/services/CombatService.ts`|Under Construction|Tracks damage & kill credit|
+|Server|`server/services/TargetingService.ts`|Usable|Validates and replicates target selection|
 |Server|`server/entity/npc/NPC.ts`|Usable|NPC instance with random names|
 |Server|`server/entity/entityResource/EntityResource.ts`|Usable|Drops collectible resource|
 |Server|`server/entity/EvolvingOrganism.ts`|Under Construction|DNA‑driven organism|

--- a/src/client/TargetingClient.ts
+++ b/src/client/TargetingClient.ts
@@ -1,0 +1,50 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        TargetingClient.ts
+ * @module      TargetingClient
+ * @layer       Client
+ * @description Client helpers for selecting targets.
+ */
+
+import { Players, UserInputService, Workspace } from "@rbxts/services";
+import { TargetingRemotes } from "shared/network/targeting.remotes";
+import { SSEntity } from "shared/types/SSEntity";
+
+let current: SSEntity | undefined;
+
+TargetingRemotes.Client.Get("TargetSelected").Connect((entity) => {
+    current = entity;
+});
+
+TargetingRemotes.Client.Get("TargetCleared").Connect(() => {
+    current = undefined;
+});
+
+function entityFromRay(): SSEntity | undefined {
+    const camera = Workspace.CurrentCamera;
+    if (!camera) return undefined;
+    const pos = UserInputService.GetMouseLocation();
+    const ray = camera.ScreenPointToRay(pos.X, pos.Y);
+    const result = Workspace.Raycast(ray.Origin, ray.Direction.mul(100));
+    if (!result) return undefined;
+    const model = result.Instance.FindFirstAncestorOfClass("Model");
+    if (model && model.FindFirstChild("Humanoid")) {
+        return model as SSEntity;
+    }
+    return undefined;
+}
+
+export const Targeting = {
+    getTarget(): SSEntity | undefined {
+        return current;
+    },
+    requestSelect() {
+        const entity = entityFromRay();
+        if (entity) {
+            TargetingRemotes.Client.Get("SelectTarget").SendToServer(entity);
+        } else {
+            TargetingRemotes.Client.Get("ClearTarget").SendToServer();
+        }
+    },
+};

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -13,3 +13,4 @@
 export * from "./states";
 export * from "./network";
 export * from "./ui";
+export * from "./TargetingClient";

--- a/src/server/services/TargetingService.ts
+++ b/src/server/services/TargetingService.ts
@@ -1,0 +1,66 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        TargetingService.ts
+ * @module      TargetingService
+ * @layer       Server/Services
+ * @description Validates player target selections and replicates them.
+ */
+
+import { Workspace } from "@rbxts/services";
+import { TargetingRemotes } from "shared/network/targeting.remotes";
+import { SSEntity } from "shared/types/SSEntity";
+
+interface PlayerState {
+    target?: SSEntity;
+}
+
+export class TargetingService {
+    private static instance?: TargetingService;
+    private entities = new Set<SSEntity>();
+    private playerState = new Map<Player, PlayerState>();
+    private maxRange = 50;
+
+    private constructor() {
+        const selectEvt = TargetingRemotes.Server.Get("SelectTarget");
+        const clearEvt = TargetingRemotes.Server.Get("ClearTarget");
+        selectEvt.Connect((player, entity) => this.handleSelect(player, entity));
+        clearEvt.Connect((player) => this.clearTarget(player));
+    }
+
+    public static Start() {
+        if (!this.instance) {
+            this.instance = new TargetingService();
+        }
+        return this.instance;
+    }
+
+    public registerEntity(entity: SSEntity) {
+        this.entities.add(entity);
+    }
+
+    public clearTarget(player: Player) {
+        const state = this.playerState.get(player);
+        if (state && state.target) {
+            this.playerState.set(player, {});
+            TargetingRemotes.Server.Get("TargetCleared").SendToPlayer(player);
+        }
+    }
+
+    private handleSelect(player: Player, entity: SSEntity) {
+        if (!this.entities.has(entity)) return;
+        const char = player.Character;
+        const hrp = char && char.FindFirstChild("HumanoidRootPart") as BasePart;
+        const targetRoot = entity.PrimaryPart ?? entity.FindFirstChild("HumanoidRootPart") as BasePart;
+        if (!hrp || !targetRoot) return;
+        const distance = hrp.Position.sub(targetRoot.Position).Magnitude;
+        if (distance > this.maxRange) return;
+        const params = new RaycastParams();
+        params.FilterDescendantsInstances = [char, entity];
+        params.FilterType = Enum.RaycastFilterType.Exclude;
+        const result = Workspace.Raycast(hrp.Position, targetRoot.Position.sub(hrp.Position), params);
+        if (result && result.Instance && !entity.IsAncestorOf(result.Instance)) return;
+        this.playerState.set(player, { target: entity });
+        TargetingRemotes.Server.Get("TargetSelected").SendToPlayer(player, entity);
+    }
+}

--- a/src/server/services/TargetingSystem.spec.ts
+++ b/src/server/services/TargetingSystem.spec.ts
@@ -1,0 +1,73 @@
+/// <reference types="@rbxts/testez/globals" />
+import { Workspace } from "@rbxts/services";
+import { TargetingService } from "./TargetingService";
+import { SSEntity } from "shared/types/SSEntity";
+
+function createEntity(pos: Vector3): SSEntity {
+    const model = new Instance("Model");
+    const humanoid = new Instance("Humanoid");
+    humanoid.Parent = model;
+    const root = new Instance("Part");
+    root.Name = "HumanoidRootPart";
+    root.Position = pos;
+    root.Parent = model;
+    (model as unknown as { Humanoid: Humanoid; HumanoidRootPart: BasePart }).Humanoid = humanoid;
+    (model as unknown as { HumanoidRootPart: BasePart }).HumanoidRootPart = root;
+    model.PrimaryPart = root;
+    model.Parent = Workspace;
+    return model as unknown as SSEntity;
+}
+
+function createPlayer(pos: Vector3): Player {
+    const player = {} as Player;
+    const char = new Instance("Model");
+    const hrp = new Instance("Part");
+    hrp.Name = "HumanoidRootPart";
+    hrp.Position = pos;
+    hrp.Parent = char;
+    char.PrimaryPart = hrp;
+    char.Parent = Workspace;
+    (player as unknown as { Character: Model }).Character = char;
+    return player;
+}
+
+export = () => {
+    describe("TargetingService", () => {
+        it("selects targets in range and LOS", () => {
+            const svc = TargetingService.Start();
+            const player = createPlayer(new Vector3(0,0,0));
+            const target = createEntity(new Vector3(0,0,-10));
+            svc.registerEntity(target);
+            (svc as unknown as { handleSelect(p: Player, e: SSEntity): void }).handleSelect(player, target);
+            const state = (svc as unknown as { playerState: Map<Player, { target?: SSEntity }> }).playerState.get(player);
+            expect(state?.target).to.equal(target);
+            player.Destroy();
+            target.Destroy();
+        });
+
+        it("rejects targets out of range", () => {
+            const svc = TargetingService.Start();
+            const player = createPlayer(new Vector3(0,0,0));
+            const target = createEntity(new Vector3(100,0,0));
+            svc.registerEntity(target);
+            (svc as unknown as { handleSelect(p: Player, e: SSEntity): void }).handleSelect(player, target);
+            const state = (svc as unknown as { playerState: Map<Player, { target?: SSEntity }> }).playerState.get(player);
+            expect(state).never.to.be.ok();
+            player.Destroy();
+            target.Destroy();
+        });
+
+        it("clears a selected target", () => {
+            const svc = TargetingService.Start();
+            const player = createPlayer(new Vector3(0,0,0));
+            const target = createEntity(new Vector3(0,0,-5));
+            svc.registerEntity(target);
+            (svc as unknown as { handleSelect(p: Player, e: SSEntity): void }).handleSelect(player, target);
+            svc.clearTarget(player);
+            const state = (svc as unknown as { playerState: Map<Player, { target?: SSEntity }> }).playerState.get(player);
+            expect(state?.target).never.to.be.ok();
+            player.Destroy();
+            target.Destroy();
+        });
+    });
+};

--- a/src/server/services/index.ts
+++ b/src/server/services/index.ts
@@ -44,3 +44,4 @@ export * from "./ProgressionService";
 export * from "./WeaponService";
 export * from "./OrganismService";
 export * from "./CombatService";
+export * from "./TargetingService";

--- a/src/shared/network/index.ts
+++ b/src/shared/network/index.ts
@@ -18,3 +18,4 @@
  */
 
 export * from "./Definitions";
+export * from "./targeting.remotes";

--- a/src/shared/network/targeting.remotes.ts
+++ b/src/shared/network/targeting.remotes.ts
@@ -1,0 +1,18 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        targeting.remotes.ts
+ * @module      TargetingRemotes
+ * @layer       Shared/Network
+ * @description Net definitions for targeting events.
+ */
+
+import Net from "@rbxts/net";
+import { SSEntity } from "shared/types/SSEntity";
+
+export const TargetingRemotes = Net.Definitions.Create({
+    SelectTarget: Net.Definitions.ClientToServerEvent<[target: SSEntity]>(),
+    ClearTarget: Net.Definitions.ClientToServerEvent<[]>(),
+    TargetSelected: Net.Definitions.ServerToClientEvent<[target: SSEntity]>(),
+    TargetCleared: Net.Definitions.ServerToClientEvent<[]>(),
+});


### PR DESCRIPTION
## Summary
- implement server TargetingService and client module
- create net remotes for TargetSelected and TargetCleared
- add placeholder TargetIndicator asset
- document design overview
- add tests for range and deselect logic
- update barrel exports and development summary

## Testing
- `npm run build`
- `npm test` *(fails: npm warns about http-proxy, testez output not shown)*

------
https://chatgpt.com/codex/tasks/task_e_687f9a75e7188327b93eca0794bede80